### PR TITLE
PT-Meny: Borttagningsfunktioner, UI-uppdatering och Null-fixar

### DIFF
--- a/Data/clients.json
+++ b/Data/clients.json
@@ -3,40 +3,23 @@
     "CurrentWorkoutPlan": null,
     "CurrentDietPlan": null,
     "AssignedPtId": 1,
-    "WorkoutPlanIds": [],
-    "DietPlanIds": [
-      5
-    ],
-    "ProgressLogIds": [],
-    "GoalDescription": "g\u00E5uppvikt",
-    "TargetWeight": 60,
-    "WorkoutsPerWeek": 4,
-    "Id": 4,
-    "Username": "mohammed",
-    "PasswordHash": "Hejhej123",
-    "FirstName": "mohamed",
-    "LastName": "yusur",
-    "Role": "Client"
-  },
-  {
-    "CurrentWorkoutPlan": null,
-    "CurrentDietPlan": null,
-    "AssignedPtId": 1,
     "WorkoutPlanIds": [
-      2
+      1,
+      4,
+      5
     ],
     "DietPlanIds": [
       1,
-      2,
-      3,
-      4
+      4,
+      5
     ],
     "ProgressLogIds": [],
-    "GoalDescription": "bygga musklarna ",
-    "TargetWeight": 74,
+    "GoalDescription": "G\u00E5 ner i vikt",
+    "TargetWeight": 80,
     "WorkoutsPerWeek": 4,
-    "Id": 5,
-    "Username": "Klient1",
+    "TargetCalories": 2000,
+    "Id": 2,
+    "Username": "Klas",
     "PasswordHash": "Klas123456",
     "FirstName": "Klas",
     "LastName": "Olsson",
@@ -47,18 +30,43 @@
     "CurrentDietPlan": null,
     "AssignedPtId": 1,
     "WorkoutPlanIds": [
-      1
+      2
     ],
-    "DietPlanIds": [],
+    "DietPlanIds": [
+      2
+    ],
     "ProgressLogIds": [],
-    "GoalDescription": "g\u00E5 nervikt",
-    "TargetWeight": 120,
+    "GoalDescription": "Bygga muskler",
+    "TargetWeight": 75,
     "WorkoutsPerWeek": 6,
-    "Id": 6,
-    "Username": "Klas1",
-    "PasswordHash": "Klas123456",
-    "FirstName": "Klas",
-    "LastName": "Ols",
+    "TargetCalories": 2500,
+    "Id": 3,
+    "Username": "Anna",
+    "PasswordHash": "Anna123456",
+    "FirstName": "Anna",
+    "LastName": "Andersson",
+    "Role": "Client"
+  },
+  {
+    "CurrentWorkoutPlan": null,
+    "CurrentDietPlan": null,
+    "AssignedPtId": 1,
+    "WorkoutPlanIds": [
+      3
+    ],
+    "DietPlanIds": [
+      3
+    ],
+    "ProgressLogIds": [],
+    "GoalDescription": "Bli stark som hulken",
+    "TargetWeight": 100,
+    "WorkoutsPerWeek": 7,
+    "TargetCalories": 4000,
+    "Id": 4,
+    "Username": "Nemo",
+    "PasswordHash": "Nemo123456",
+    "FirstName": "Nemo",
+    "LastName": "Sensei",
     "Role": "Client"
   }
 ]

--- a/Data/diets.json
+++ b/Data/diets.json
@@ -1,316 +1,316 @@
 [
   {
     "Id": 1,
-    "ClientId": 5,
-    "Name": "Inget m\u00E5l satt 2000 kcal",
+    "ClientId": 2,
+    "Name": "G\u00E5 ner i vikt 2000 kcal",
     "DailyMeals": [
       {
         "Day": "M\u00E5ndag",
-        "Breakfast": "Havregrynsgr\u00F6t med b\u00E4r och honung",
-        "Lunch": "Kycklingsallad med quinoa och gr\u00F6nsaker",
-        "Dinner": "Lax med s\u00F6tpotatis och broccoli",
-        "Snacks": "En banan och en n\u00E4ve mandlar",
-        "TotalCalories": 2005
+        "Breakfast": "Havregrynsgr\u00F6t med b\u00E4r och en matsked honung",
+        "Lunch": "Kycklingsallad med gr\u00F6nsaker och balsamvin\u00E4ger",
+        "Dinner": "Grillad lax med quinoa och \u00E5ngade broccolibuketter",
+        "Snacks": "En frukt och en n\u00E4ve mandlar",
+        "TotalCalories": 1980
       },
       {
         "Day": "Tisdag",
-        "Breakfast": "Fullkornsbr\u00F6d med avokado och pocherat \u00E4gg",
-        "Lunch": "Tonfisksallad med b\u00F6nor och gr\u00F6nsaker",
-        "Dinner": "K\u00F6ttf\u00E4rss\u00E5s med fullkornspasta och gr\u00F6nsaker",
-        "Snacks": "En \u00E4pple och ett par riskakor",
-        "TotalCalories": 1997
+        "Breakfast": "Smoothie med spenat, banan och proteinpulver",
+        "Lunch": "Fullkornswrap med kalkon, avokado och gr\u00F6nsaker",
+        "Dinner": "Biffsallad med edamame och sesamfr\u00F6n",
+        "Snacks": "Morotsstavar med hummus",
+        "TotalCalories": 2010
       },
       {
         "Day": "Onsdag",
-        "Breakfast": "Smoothie med spenat, banan och proteinpulver",
-        "Lunch": "Quinoasallad med grillade gr\u00F6nsaker och fetaost",
-        "Dinner": "Kycklingfil\u00E9 med cashews och wokade gr\u00F6nsaker",
-        "Snacks": "Morotsstavar med hummus",
-        "TotalCalories": 2003
+        "Breakfast": "Yoghurt med granola och b\u00E4r",
+        "Lunch": "Quinoasallad med kik\u00E4rtor och fetaost",
+        "Dinner": "Stekt torsk med bulgur och gr\u00F6nsaker",
+        "Snacks": "En frukt och n\u00E5gra valn\u00F6tter",
+        "TotalCalories": 1995
       },
       {
         "Day": "Torsdag",
-        "Breakfast": "Yoghurt med granola och b\u00E4r",
-        "Lunch": "R\u00F6kt lax med gr\u00F6nsakswrap",
-        "Dinner": "Vegansk chili med b\u00F6nor och ris",
-        "Snacks": "En handfull valn\u00F6tter och en p\u00E4ron",
-        "TotalCalories": 2001
+        "Breakfast": "\u00C4ggr\u00F6ra med spenat och tomat",
+        "Lunch": "R\u00F6dbetssallad med getost och rucola",
+        "Dinner": "Kycklingfil\u00E9 med s\u00F6tt ris och gr\u00F6nsaker",
+        "Snacks": "Skivor av gurka och paprika med tzatziki",
+        "TotalCalories": 1985
       },
       {
         "Day": "Fredag",
-        "Breakfast": "Fullkorns-toast med n\u00F6tsm\u00F6r och skivade bananer",
-        "Lunch": "Kik\u00E4rts- och spenatsallad",
-        "Dinner": "Grillad biff med blomk\u00E5lsmos",
-        "Snacks": "En proteinbar",
+        "Breakfast": "Chiapudding med mandelmj\u00F6lk och b\u00E4r",
+        "Lunch": "Tofu stir-fry med gr\u00F6nsaker och fullkornsris",
+        "Dinner": "Lammf\u00E4rsbiffar med tabbouleh",
+        "Snacks": "En apelsin och en n\u00E4ve solrosfr\u00F6n",
         "TotalCalories": 2005
       },
       {
         "Day": "L\u00F6rdag",
-        "Breakfast": "Fruktsallad med kvarg och honung",
-        "Lunch": "Grillad kyckling i pita med tzatziki",
-        "Dinner": "Fiskgrat\u00E4ng med potatis och \u00E4rtor",
-        "Snacks": "Popcorn och en apelsin",
-        "TotalCalories": 2002
+        "Breakfast": "Pannkakor med havremj\u00F6l och banan",
+        "Lunch": "Tonfisksallad med b\u00F6nor och avokado",
+        "Dinner": "Grillade gr\u00F6nsaker med polenta",
+        "Snacks": "Yoghurt med n\u00F6tter",
+        "TotalCalories": 1998
       },
       {
         "Day": "S\u00F6ndag",
-        "Breakfast": "Havrepannkakor med b\u00E4r",
-        "Lunch": "Sushi med lax och avokado",
-        "Dinner": "Vegetarisk lasagne med spenat och ricotta",
-        "Snacks": "En handfull n\u00F6tter och m\u00F6rk choklad",
-        "TotalCalories": 2004
+        "Breakfast": "Fruktsallad med kvarg",
+        "Lunch": "Kik\u00E4rtsgryta med spenat och ris",
+        "Dinner": "Ugnsbakad kyckling med rotfrukter",
+        "Snacks": "Popcorn och en frukt",
+        "TotalCalories": 2001
       }
     ]
   },
   {
     "Id": 2,
-    "ClientId": 5,
-    "Name": "Inget m\u00E5l satt 2000 kcal",
+    "ClientId": 3,
+    "Name": "Bygga muskler 2500 kcal",
     "DailyMeals": [
       {
         "Day": "M\u00E5ndag",
-        "Breakfast": "Havregrynsgr\u00F6t med b\u00E4r och honung",
-        "Lunch": "Lins- och gr\u00F6nsakssoppa med fullkornsbr\u00F6d",
-        "Dinner": "Grillad kyckling med quinoa och \u00E5ngade gr\u00F6nsaker",
-        "Snacks": "En banan och en handfull mandlar",
-        "TotalCalories": 2005
+        "Breakfast": "\u00C4ggr\u00F6ra med spenat och tomat samt fullkornsbr\u00F6d",
+        "Lunch": "Grillad kyckling med quinoa och \u00E5ngade gr\u00F6nsaker",
+        "Dinner": "Oxfil\u00E9 med s\u00F6tpotatis och gr\u00F6nsallad",
+        "Snacks": "Grekisk yoghurt med honung och valn\u00F6tter",
+        "TotalCalories": 2500
       },
       {
         "Day": "Tisdag",
-        "Breakfast": "Yoghurt med granola och frukt",
-        "Lunch": "Tonfisksallad med avokado och b\u00F6nor",
-        "Dinner": "Biff med s\u00F6tpotatispommes och broccoli",
-        "Snacks": "En apelsin och ett par m\u00F6rka chokladbitar",
-        "TotalCalories": 1990
+        "Breakfast": "Havregrynsgr\u00F6t med \u00E4pple och kanel",
+        "Lunch": "Laxfil\u00E9 med fullkornspasta och broccolimos",
+        "Dinner": "K\u00F6ttf\u00E4rss\u00E5s med b\u00F6npasta och parmesan",
+        "Snacks": "Smoothie med banan, proteinpulver och jordn\u00F6tssm\u00F6r",
+        "TotalCalories": 2490
       },
       {
         "Day": "Onsdag",
-        "Breakfast": "Smoothie med spenat, banan och proteinpulver",
-        "Lunch": "Kik\u00E4rtsbowl med gr\u00F6nsaker och tahinis\u00E5s",
-        "Dinner": "Ugnsbakad lax med potatis och sparris",
-        "Snacks": "Ett \u00E4pple och en n\u00E4ve valn\u00F6tter",
-        "TotalCalories": 2015
+        "Breakfast": "Proteinsmoothie med b\u00E4r och havregryn",
+        "Lunch": "Kik\u00E4rtssallad med fetaost och olivolja",
+        "Dinner": "Grillad kyckling med ris och wokade gr\u00F6nsaker",
+        "Snacks": "En n\u00E4ve n\u00F6tter och en banan",
+        "TotalCalories": 2510
       },
       {
         "Day": "Torsdag",
-        "Breakfast": "Fullkornsrostade mackor med \u00E4gg och avokado",
-        "Lunch": "Gr\u00F6nsakswrap med hummus och kalkon",
-        "Dinner": "Vegetarisk lasagne med ricotta och spenat",
-        "Snacks": "Bj\u00F6rnb\u00E4r och en handfull n\u00F6tter",
-        "TotalCalories": 1987
+        "Breakfast": "Omlett med skinka och ost samt fullkornsbr\u00F6d",
+        "Lunch": "Tonfisk med ris och gr\u00F6nsaker",
+        "Dinner": "Fl\u00E4skkotlett med potatismos och gr\u00F6nsallad",
+        "Snacks": "Hummus med morotsstavar",
+        "TotalCalories": 2505
       },
       {
         "Day": "Fredag",
-        "Breakfast": "Pannkakor med b\u00E4r och l\u00F6nnsirap",
-        "Lunch": "Quinoasallad med fetaost och gurka",
-        "Dinner": "Grillade r\u00E4kor med ris och gr\u00F6nsaker",
-        "Snacks": "En smoothie med b\u00E4r och chiafr\u00F6n",
-        "TotalCalories": 2003
+        "Breakfast": "Chiapudding med banan och mandelmj\u00F6lk",
+        "Lunch": "Kycklingwrap med avokado och gr\u00F6nsaker",
+        "Dinner": "Grillad lax med couscous och spenatsallad",
+        "Snacks": "Proteinbar och en frukt",
+        "TotalCalories": 2480
       },
       {
         "Day": "L\u00F6rdag",
-        "Breakfast": "Chiapudding med kokosmj\u00F6lk och frukt",
-        "Lunch": "Kycklingfajitas med gr\u00F6nsaker och tortilla",
-        "Dinner": "Fl\u00E4skfil\u00E9 med potatismos och gr\u00F6nsaker",
-        "Snacks": "En p\u00E4ron och n\u00E5gra pistagen\u00F6tter",
-        "TotalCalories": 1995
+        "Breakfast": "Pannkakor med proteinpulver och b\u00E4r",
+        "Lunch": "Nudelsallad med teriyakis\u00E5s och r\u00E4kor",
+        "Dinner": "Helstekt kyckling med potatis och rostad sparris",
+        "Snacks": "Yoghurt med energimix",
+        "TotalCalories": 2520
       },
       {
         "Day": "S\u00F6ndag",
-        "Breakfast": "Omelett med spenat och tomat samt fullkornsbr\u00F6d",
-        "Lunch": "Grekisk sallad med oliver och fetaost",
-        "Dinner": "Vegetarisk curry med ris och linser",
-        "Snacks": "En proteinbar och en frukt",
-        "TotalCalories": 2002
+        "Breakfast": "Rostat br\u00F6d med avokado och pocherat \u00E4gg",
+        "Lunch": "S\u00F6ndagsstek med gr\u00F6nsaker och bruns\u00E5s",
+        "Dinner": "Vegetarisk gryta med b\u00F6nor och ris",
+        "Snacks": "Snap peas och proteinshake",
+        "TotalCalories": 2500
       }
     ]
   },
   {
     "Id": 3,
-    "ClientId": 5,
-    "Name": "Bli hulken 2000 kcal",
+    "ClientId": 4,
+    "Name": "Bli stark som hulken 4000 kcal",
     "DailyMeals": [
       {
         "Day": "M\u00E5ndag",
-        "Breakfast": "\u00C4ggr\u00F6ra med spenat och fetaost",
+        "Breakfast": "Havregrynsgr\u00F6t med mj\u00F6lk, banan och mandlar",
         "Lunch": "Grillad kyckling med quinoa och gr\u00F6nsaker",
-        "Dinner": "Lax med fullkornspasta och broccolimos",
-        "Snacks": "N\u00F6tter och en proteinshake",
-        "TotalCalories": 1980
+        "Dinner": "N\u00F6tf\u00E4rsbiffar med s\u00F6tpotatis och broccoli",
+        "Snacks": "Proteinsmoothie och en handfull valn\u00F6tter",
+        "TotalCalories": 3980
       },
       {
         "Day": "Tisdag",
-        "Breakfast": "Havregrynsgr\u00F6t med banan och mandlar",
-        "Lunch": "Kik\u00E4rts- och avokadosallad",
-        "Dinner": "K\u00F6ttf\u00E4rsbiffar med s\u00F6tpotatis och gr\u00F6nsaker",
-        "Snacks": "Yoghurt med b\u00E4r",
-        "TotalCalories": 2015
+        "Breakfast": "Scrambled eggs med spenat och fullkornsbr\u00F6d",
+        "Lunch": "Lax med ris och avokadosallad",
+        "Dinner": "Kycklingwok med gr\u00F6nsaker och cashewn\u00F6tter",
+        "Snacks": "Hummus med morotsstavar och en proteinbar",
+        "TotalCalories": 4020
       },
       {
         "Day": "Onsdag",
-        "Breakfast": "Smoothie med spenat, proteinpulver och jordgubbar",
-        "Lunch": "Tonfisksallad med b\u00F6nor och avokado",
-        "Dinner": "Kycklingrulle med fullkornsbr\u00F6d och gr\u00F6nsaker",
-        "Snacks": "Energibars",
-        "TotalCalories": 1995
+        "Breakfast": "Smoothie bowl med b\u00E4r, n\u00F6tter och chiafr\u00F6n",
+        "Lunch": "Biff med fullkornsbulgur och grillade gr\u00F6nsaker",
+        "Dinner": "Bakad torsk med potatis och \u00F6rts\u00E5s",
+        "Snacks": "Keso med frukt och en handfull mandlar",
+        "TotalCalories": 3995
       },
       {
         "Day": "Torsdag",
-        "Breakfast": "Fullkorns toast med \u00E4gg och avokado",
-        "Lunch": "Bulgursallad med fetaost och gr\u00F6nsaker",
-        "Dinner": "Fl\u00E4skfil\u00E9 med rostad blomk\u00E5l och potatis",
-        "Snacks": "En frukt och mandlar",
-        "TotalCalories": 2020
+        "Breakfast": "Yoghurt med granola och honung",
+        "Lunch": "Kalkonwrap med avokado och salsa",
+        "Dinner": "Fl\u00E4skfil\u00E9 med ugnsrostade rotfrukter",
+        "Snacks": "Proteinshake och en energibar",
+        "TotalCalories": 4015
       },
       {
         "Day": "Fredag",
-        "Breakfast": "Chiapudding med kokos och b\u00E4r",
-        "Lunch": "Grillad lax med brun ris och sparris",
-        "Dinner": "Kalkonburgare med s\u00F6tpotatispommes",
-        "Snacks": "Keso med frukt",
-        "TotalCalories": 1985
+        "Breakfast": "Omelett med paprika, l\u00F6k och fetaost",
+        "Lunch": "R\u00E4ksallad med quinoa och avokado",
+        "Dinner": "Lammkotletter med couscous och gr\u00F6nsaker",
+        "Snacks": "\u00C4pple och jordn\u00F6tssm\u00F6r, samt en handfull pistaschn\u00F6tter",
+        "TotalCalories": 3988
       },
       {
         "Day": "L\u00F6rdag",
-        "Breakfast": "Pannkakor med havremj\u00F6l och b\u00E4r",
-        "Lunch": "Quinoasallad med r\u00E4kor och gr\u00F6nsaker",
-        "Dinner": "Nudlar med teriyakis\u00E5s och tofu",
-        "Snacks": "Hummus med gr\u00F6nsaksstavar",
-        "TotalCalories": 2005
+        "Breakfast": "Pannkakor med b\u00E4r och l\u00F6nnsirap",
+        "Lunch": "Vegetarisk lasagne med spenat och ricotta",
+        "Dinner": "Grillad tonfisk med risnudlar och gr\u00F6nsaker",
+        "Snacks": "Energiboll med dadlar och n\u00F6tter",
+        "TotalCalories": 4005
       },
       {
         "Day": "S\u00F6ndag",
-        "Breakfast": "Omelett med svamp och paprika",
-        "Lunch": "Kycklingcurry med basmatiris",
-        "Dinner": "Torsk med potatismos och \u00E4rtor",
-        "Snacks": "Proteinshake och en frukt",
-        "TotalCalories": 1990
+        "Breakfast": "Chiafr\u00F6gr\u00F6t med frukt och n\u00F6tter",
+        "Lunch": "Taco med k\u00F6ttf\u00E4rs, gr\u00F6nsaker och guacamole",
+        "Dinner": "Stekt kyckling med potatisgrat\u00E4ng",
+        "Snacks": "Smoothie med proteinpulver och en handfull mandlar",
+        "TotalCalories": 3992
       }
     ]
   },
   {
     "Id": 4,
-    "ClientId": 5,
-    "Name": "G\u00E5 upp vikt 1000 kcal",
+    "ClientId": 2,
+    "Name": "G\u00E5 ner i vikt 2000 kcal",
     "DailyMeals": [
       {
         "Day": "M\u00E5ndag",
-        "Breakfast": "Yoghurt med granola och honung",
-        "Lunch": "Kik\u00E4rts- och avokadosallad",
-        "Dinner": "Grillad kyckling med quinoa och gr\u00F6nsaker",
-        "Snacks": "N\u00F6tter och ett \u00E4pple",
-        "TotalCalories": 1005
+        "Breakfast": "Omelett med spenat och tomat",
+        "Lunch": "Grillad kyckling med quinoa och broccoli",
+        "Dinner": "Stekt torsk med s\u00F6tpotatis och gr\u00F6nsaker",
+        "Snacks": "\u00C4pple och en handfull mandlar",
+        "TotalCalories": 1995
       },
       {
         "Day": "Tisdag",
-        "Breakfast": "Smoothie med banan, spenat och proteinpulver",
-        "Lunch": "Tonfisksallad med olivolja",
-        "Dinner": "K\u00F6ttf\u00E4rss\u00E5s med fullkornspasta",
-        "Snacks": "Hummus med morotsstavar",
-        "TotalCalories": 995
+        "Breakfast": "Havregrynsgr\u00F6t med b\u00E4r och honung",
+        "Lunch": "Tonfisk-sallad med kik\u00E4rtor och gr\u00F6na blad",
+        "Dinner": "Vegan tacos med svarta b\u00F6nor och avokado",
+        "Snacks": "Morotsstavar med hummus",
+        "TotalCalories": 2001
       },
       {
         "Day": "Onsdag",
-        "Breakfast": "\u00C4ggr\u00F6ra med avokado och fullkornsbr\u00F6d",
-        "Lunch": "Quinoabowl med b\u00F6nor och gr\u00F6nsaker",
-        "Dinner": "Lax med s\u00F6ttpotatismos",
-        "Snacks": "En proteinbar",
-        "TotalCalories": 1002
+        "Breakfast": "Grekisk yoghurt med n\u00F6tter och honung",
+        "Lunch": "Kycklingwrap med gr\u00F6nsaker och tzatziki",
+        "Dinner": "Lax med rostad blomk\u00E5l och gr\u00F6na b\u00F6nor",
+        "Snacks": "Banan och en handfull valn\u00F6tter",
+        "TotalCalories": 1998
       },
       {
         "Day": "Torsdag",
-        "Breakfast": "Havregrynsgr\u00F6t med b\u00E4r och mandelmj\u00F6lk",
-        "Lunch": "Kycklingwrap med gr\u00F6nsaker",
-        "Dinner": "Grillad tofustirfry med ris",
-        "Snacks": "Gr\u00F6n smoothie med avokado",
-        "TotalCalories": 1010
+        "Breakfast": "Smoothie med spenat, banan och mandelmj\u00F6lk",
+        "Lunch": "Vegetarisk b\u00F6nsoppa med fullkornsbr\u00F6d",
+        "Dinner": "Grillad flankstek med quinoa och sparris",
+        "Snacks": "En sk\u00E5l med b\u00E4r",
+        "TotalCalories": 2003
       },
       {
         "Day": "Fredag",
-        "Breakfast": "Chiapudding med kokos och frukt",
-        "Lunch": "F\u00E4rsk pasta med pesto och gr\u00F6nsaker",
-        "Dinner": "Grillad fisk med couscous",
-        "Snacks": "Yoghurt med b\u00E4r",
-        "TotalCalories": 1003
+        "Breakfast": "\u00C4ggr\u00F6ra med avokado och fullkornsrostat br\u00F6d",
+        "Lunch": "Kalkonburgare med s\u00F6tpotatispommes",
+        "Dinner": "R\u00F6dsp\u00E4tta med citron och \u00E5ngad broccoli",
+        "Snacks": "Dadel och n\u00F6tmix",
+        "TotalCalories": 1997
       },
       {
         "Day": "L\u00F6rdag",
-        "Breakfast": "Pannkakor med l\u00F6nnsirap och frukt",
-        "Lunch": "Bulgursallad med fetaost",
-        "Dinner": "Oxfil\u00E9 med ugnsrostade gr\u00F6nsaker",
-        "Snacks": "N\u00F6tmix",
-        "TotalCalories": 1007
+        "Breakfast": "Chiapudding med kokosmj\u00F6lk och mango",
+        "Lunch": "Quinoasalad med fetaost och oliver",
+        "Dinner": "Kryddig kyckling med basmatiris och gr\u00F6nsaker",
+        "Snacks": "P\u00E4ron och en handfull pumpak\u00E4rnor",
+        "TotalCalories": 2002
       },
       {
         "Day": "S\u00F6ndag",
-        "Breakfast": "Smoothie bowl med n\u00F6tter och frukt",
-        "Lunch": "R\u00F6dbetssallad med getost",
-        "Dinner": "Bakad kyckling med s\u00F6tpotatis",
-        "Snacks": "Hummus och pita",
-        "TotalCalories": 998
+        "Breakfast": "Fruktsallad med yoghurt och granola",
+        "Lunch": "Biff med gr\u00F6nsaksr\u00F6ra och potatismos",
+        "Dinner": "Bakad torsk med \u00E4rtor och potatis",
+        "Snacks": "Klick vaniljyoghurt med kanel",
+        "TotalCalories": 1994
       }
     ]
   },
   {
     "Id": 5,
-    "ClientId": 4,
-    "Name": "G\u00E5uppvikt 1500 kcal",
+    "ClientId": 2,
+    "Name": "G\u00E5 ner i vikt 2000 kcal",
     "DailyMeals": [
       {
         "Day": "M\u00E5ndag",
-        "Breakfast": "Havregrynsgr\u00F6t med banan och mandelmj\u00F6lk",
-        "Lunch": "Quinoasallad med b\u00F6nor och avokado",
-        "Dinner": "Kycklingfil\u00E9 med broccoli och fullkornsris",
-        "Snacks": "N\u00F6tter och en proteinbar",
-        "TotalCalories": 1500
+        "Breakfast": "Havregrynsgr\u00F6t med bl\u00E5b\u00E4r och mandlar",
+        "Lunch": "Grillad kyckling med quinoa och gr\u00F6nsallad",
+        "Dinner": "Laxfil\u00E9 med s\u00F6tpotatis och broccoli",
+        "Snacks": "En \u00E4pple och 10 mandlar",
+        "TotalCalories": 1985
       },
       {
         "Day": "Tisdag",
-        "Breakfast": "Smoothiebowl med spenat, banan och jordn\u00F6tssm\u00F6r",
-        "Lunch": "Lax med quinoa och gr\u00F6nsaker",
-        "Dinner": "K\u00F6ttf\u00E4rss\u00E5s med pasta",
-        "Snacks": "Yoghurt med honung och fr\u00F6n",
-        "TotalCalories": 1490
+        "Breakfast": "Smoothie med spenat, banan och proteinpulver",
+        "Lunch": "Kik\u00E4rtsallad med tomat, gurka och fetaost",
+        "Dinner": "Kalkonbiffar med ugnsrostade gr\u00F6nsaker",
+        "Snacks": "Grekisk yoghurt med honung och valn\u00F6tter",
+        "TotalCalories": 2010
       },
       {
         "Day": "Onsdag",
-        "Breakfast": "\u00C4ggr\u00F6ra med spenat och tomat",
-        "Lunch": "Wrap med kyckling, gr\u00F6nsaker och hummus",
-        "Dinner": "Grillad lax med s\u00F6tpotatis och sparris",
-        "Snacks": "En frukt och en handfull n\u00F6tter",
-        "TotalCalories": 1510
+        "Breakfast": "\u00C4ggr\u00F6ra med spenat och fullkornsbr\u00F6d",
+        "Lunch": "Tonfisksallad med avokado och blandad sallad",
+        "Dinner": "Kycklingwok med broccoli, paprika och r\u00E5ris",
+        "Snacks": "Morotsstavar med hummus",
+        "TotalCalories": 1995
       },
       {
         "Day": "Torsdag",
-        "Breakfast": "Chiapudding med b\u00E4r och mandlar",
-        "Lunch": "Tonfisksallad med avokado och kik\u00E4rtor",
-        "Dinner": "Kycklingwok med gr\u00F6nsaker och fullkornsris",
-        "Snacks": "Keso med frukt",
-        "TotalCalories": 1505
+        "Breakfast": "Chiapudding med kokosmj\u00F6lk och b\u00E4r",
+        "Lunch": "Quinoasallad med grillad paprika och fetaost",
+        "Dinner": "Fisk tacos med kall s\u00E5s och k\u00E5l",
+        "Snacks": "En banan och en handfull n\u00F6tter",
+        "TotalCalories": 2005
       },
       {
         "Day": "Fredag",
-        "Breakfast": "Omelett med champinjoner och paprika",
-        "Lunch": "R\u00F6dbetssallad med fetaost och valn\u00F6tter",
-        "Dinner": "Fiskgrat\u00E4ng med potatismos",
-        "Snacks": "Proteinshake och n\u00E5gra riskakor",
-        "TotalCalories": 1480
+        "Breakfast": "Fullkornsbagel med avokado och tomat",
+        "Lunch": "Grillad lax med couscous och sparris",
+        "Dinner": "Vegetarisk curry med linser och ris",
+        "Snacks": "En p\u00E4ron och n\u00E5gra mandlar",
+        "TotalCalories": 1980
       },
       {
         "Day": "L\u00F6rdag",
-        "Breakfast": "Pannkakor med havregryn och b\u00E4r",
-        "Lunch": "Kik\u00E4rtsgryta med kokosmj\u00F6lk",
-        "Dinner": "Biff med rostad gr\u00F6nsaker",
-        "Snacks": "M\u00F6rk choklad och en banan",
-        "TotalCalories": 1520
+        "Breakfast": "Pannkakor av havremj\u00F6l med b\u00E4r och n\u00F6tter",
+        "Lunch": "Kyckling Caesar-sallad med fullkornskrutonger",
+        "Dinner": "Ugnsbakad torsk med s\u00F6tpotatis och gr\u00F6nsaker",
+        "Snacks": "En smoothie med proteinpulver",
+        "TotalCalories": 2002
       },
       {
         "Day": "S\u00F6ndag",
-        "Breakfast": "Yoghurt med granola och b\u00E4r",
-        "Lunch": "Kycklingfajitas med gr\u00F6nsaker",
-        "Dinner": "Pasta med tomats\u00E5s och linser",
-        "Snacks": "Ett \u00E4pple och n\u00E5gra mandlar",
-        "TotalCalories": 1495
+        "Breakfast": "Omelett med gr\u00F6nsaker och fetaost",
+        "Lunch": "Bulgursallad med grillade gr\u00F6nsaker och kyckling",
+        "Dinner": "Biff med potatis och gr\u00F6nsallad",
+        "Snacks": "Yoghurt med m\u00F6rk chokladbitar",
+        "TotalCalories": 1998
       }
     ]
   }

--- a/Data/workouts.json
+++ b/Data/workouts.json
@@ -1,91 +1,69 @@
 [
   {
     "Id": 1,
-    "ClientId": 6,
-    "Name": "G\u00E5 ner i vikt 5-dagars",
+    "ClientId": 2,
+    "Name": "Viktnedg\u00E5ng 4-dagars",
     "DailyWorkouts": [
       {
         "Day": "Dag 1 (M\u00E5ndag)",
-        "FocusArea": "Kondition \u0026 Fettf\u00F6rbr\u00E4nning",
+        "FocusArea": "Helkropp",
         "Exercises": [
           {
-            "Name": "L\u00F6pning",
-            "SetsAndReps": "30 minuter"
+            "Name": "Kettlebell sving",
+            "SetsAndReps": "3 set x 12 reps"
           },
           {
-            "Name": "Burpees",
+            "Name": "Kn\u00E4b\u00F6j",
             "SetsAndReps": "3 set x 10 reps"
           },
           {
             "Name": "Plankan",
-            "SetsAndReps": "3 set x 30 sekunder"
+            "SetsAndReps": "3 set x 30 sek"
           }
         ]
       },
       {
         "Day": "Dag 2 (Tisdag)",
-        "FocusArea": "Styrka - Helkropp",
+        "FocusArea": "Kondition",
         "Exercises": [
           {
-            "Name": "Kn\u00E4b\u00F6j",
-            "SetsAndReps": "3 set x 12 reps"
+            "Name": "L\u00F6pning",
+            "SetsAndReps": "30 min"
           },
+          {
+            "Name": "Hopprep",
+            "SetsAndReps": "5 min"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 3 (Torsdag)",
+        "FocusArea": "\u00D6verkropp",
+        "Exercises": [
           {
             "Name": "B\u00E4nkpress",
             "SetsAndReps": "3 set x 10 reps"
           },
           {
-            "Name": "Rodd",
-            "SetsAndReps": "3 set x 12 reps"
-          }
-        ]
-      },
-      {
-        "Day": "Dag 3 (Onsdag)",
-        "FocusArea": "Kondition \u0026 R\u00F6rlighet",
-        "Exercises": [
-          {
-            "Name": "Cykling",
-            "SetsAndReps": "30 minuter"
+            "Name": "Pull-ups",
+            "SetsAndReps": "3 set x 8 reps"
           },
           {
-            "Name": "Yoga",
-            "SetsAndReps": "30 minuter"
-          }
-        ]
-      },
-      {
-        "Day": "Dag 4 (Torsdag)",
-        "FocusArea": "Styrka - Underkropp",
-        "Exercises": [
-          {
-            "Name": "Marklyft",
-            "SetsAndReps": "3 set x 10 reps"
-          },
-          {
-            "Name": "Vadpress",
-            "SetsAndReps": "3 set x 15 reps"
-          },
-          {
-            "Name": "Upphopp",
+            "Name": "Dips",
             "SetsAndReps": "3 set x 10 reps"
           }
         ]
       },
       {
-        "Day": "Dag 5 (Fredag)",
+        "Day": "Dag 4 (Fredag)",
         "FocusArea": "Kondition \u0026 Core",
         "Exercises": [
           {
-            "Name": "Intervalltr\u00E4ning (herkules)",
-            "SetsAndReps": "5 set x 1 minut"
+            "Name": "Cykling",
+            "SetsAndReps": "30 min"
           },
           {
-            "Name": "Russian twists",
-            "SetsAndReps": "3 set x 15 reps"
-          },
-          {
-            "Name": "Sit-ups",
+            "Name": "Russian twist",
             "SetsAndReps": "3 set x 15 reps"
           }
         ]
@@ -94,8 +72,8 @@
   },
   {
     "Id": 2,
-    "ClientId": 5,
-    "Name": "Bygga Muskler 4-dagars",
+    "ClientId": 3,
+    "Name": "Muskelbyggande 6-dagars",
     "DailyWorkouts": [
       {
         "Day": "Dag 1 (M\u00E5ndag)",
@@ -110,12 +88,8 @@
             "SetsAndReps": "3 set x 10 reps"
           },
           {
-            "Name": "Dips",
+            "Name": "Tricepsdips",
             "SetsAndReps": "3 set x 8 reps"
-          },
-          {
-            "Name": "Tricepspushdown",
-            "SetsAndReps": "3 set x 12 reps"
           }
         ]
       },
@@ -128,12 +102,8 @@
             "SetsAndReps": "4 set x 6 reps"
           },
           {
-            "Name": "Skivst\u00E5ngsrodd",
-            "SetsAndReps": "3 set x 8 reps"
-          },
-          {
-            "Name": "Pull-ups",
-            "SetsAndReps": "3 set x 6 reps"
+            "Name": "Latsdrag",
+            "SetsAndReps": "3 set x 10 reps"
           },
           {
             "Name": "Bicepscurl",
@@ -142,8 +112,123 @@
         ]
       },
       {
-        "Day": "Dag 3 (Torsdag)",
-        "FocusArea": "Ben \u0026 Axlar",
+        "Day": "Dag 3 (Onsdag)",
+        "FocusArea": "Ben",
+        "Exercises": [
+          {
+            "Name": "Kn\u00E4b\u00F6j",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Benpress",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Bensparkar",
+            "SetsAndReps": "3 set x 12 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 4 (Torsdag)",
+        "FocusArea": "Axlar \u0026 Mage",
+        "Exercises": [
+          {
+            "Name": "Axelpress",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Lateral raise",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Planka",
+            "SetsAndReps": "3 set x 30 sek"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 5 (Fredag)",
+        "FocusArea": "Br\u00F6st \u0026 Rygg",
+        "Exercises": [
+          {
+            "Name": "B\u00E4nkpress",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Skivst\u00E5ngsrodd",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Push-ups",
+            "SetsAndReps": "3 set x 10 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 6 (L\u00F6rdag)",
+        "FocusArea": "Ben \u0026 Triceps",
+        "Exercises": [
+          {
+            "Name": "Utfall",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Liggande tricepspress",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Leg curls",
+            "SetsAndReps": "3 set x 12 reps"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Id": 3,
+    "ClientId": 4,
+    "Name": "Bli stark som hulken 7-dagars",
+    "DailyWorkouts": [
+      {
+        "Day": "Dag 1 (M\u00E5ndag)",
+        "FocusArea": "Br\u00F6st \u0026 Triceps",
+        "Exercises": [
+          {
+            "Name": "B\u00E4nkpress",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Flyes",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Tricepspress",
+            "SetsAndReps": "4 set x 8 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 2 (Tisdag)",
+        "FocusArea": "Rygg \u0026 Biceps",
+        "Exercises": [
+          {
+            "Name": "Marklyft",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Pull-ups",
+            "SetsAndReps": "3 set x 6 reps"
+          },
+          {
+            "Name": "Bicep curls",
+            "SetsAndReps": "3 set x 10 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 3 (Onsdag)",
+        "FocusArea": "Ben",
         "Exercises": [
           {
             "Name": "Kn\u00E4b\u00F6j",
@@ -154,34 +239,238 @@
             "SetsAndReps": "3 set x 10 reps"
           },
           {
-            "Name": "Axelpress",
-            "SetsAndReps": "3 set x 8 reps"
-          },
-          {
-            "Name": "Lateral Raises",
+            "Name": "T\u00E5h\u00E4vningar",
             "SetsAndReps": "3 set x 12 reps"
           }
         ]
       },
       {
-        "Day": "Dag 4 (Fredag)",
-        "FocusArea": "K\u00E4rna \u0026 Cardio",
+        "Day": "Dag 4 (Torsdag)",
+        "FocusArea": "Axlar",
         "Exercises": [
           {
+            "Name": "Milit\u00E4rpress",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Sidolyft",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Framlyft",
+            "SetsAndReps": "3 set x 10 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 5 (Fredag)",
+        "FocusArea": "Br\u00F6st \u0026 Rygg",
+        "Exercises": [
+          {
+            "Name": "B\u00E4nkpress",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Skivst\u00E5ngsrodd",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Dips",
+            "SetsAndReps": "3 set x 8 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 6 (L\u00F6rdag)",
+        "FocusArea": "Ben \u0026 Biceps",
+        "Exercises": [
+          {
+            "Name": "B\u00F6j med vikter",
+            "SetsAndReps": "4 set x 8 reps"
+          },
+          {
+            "Name": "Hamstringscurl",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Hammer curls",
+            "SetsAndReps": "3 set x 10 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 7 (S\u00F6ndag)",
+        "FocusArea": "Kondition \u0026 R\u00F6rlighet",
+        "Exercises": [
+          {
+            "Name": "Intervallk\u00F6rning",
+            "SetsAndReps": "30 min"
+          },
+          {
+            "Name": "Stretching",
+            "SetsAndReps": "15 min"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Id": 4,
+    "ClientId": 2,
+    "Name": "Viktnedg\u00E5ng 4-dagars",
+    "DailyWorkouts": [
+      {
+        "Day": "Dag 1 (M\u00E5ndag)",
+        "FocusArea": "Helkropp",
+        "Exercises": [
+          {
+            "Name": "B\u00E4nkpress",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Kn\u00E4b\u00F6j",
+            "SetsAndReps": "3 set x 12 reps"
+          },
+          {
+            "Name": "Marklyft",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
             "Name": "Plankan",
-            "SetsAndReps": "3 set x 30 sekunder"
+            "SetsAndReps": "3 set x 30 sek"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 2 (Tisdag)",
+        "FocusArea": "Kondition",
+        "Exercises": [
+          {
+            "Name": "L\u00F6pning",
+            "SetsAndReps": "30 min"
           },
           {
-            "Name": "Russian Twists",
+            "Name": "Cykling",
+            "SetsAndReps": "30 min"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 3 (Torsdag)",
+        "FocusArea": "\u00D6verkropp",
+        "Exercises": [
+          {
+            "Name": "Axelpress",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Chins",
+            "SetsAndReps": "3 set x 8 reps"
+          },
+          {
+            "Name": "Tricepspress",
+            "SetsAndReps": "3 set x 12 reps"
+          },
+          {
+            "Name": "Situps",
             "SetsAndReps": "3 set x 15 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 4 (Fredag)",
+        "FocusArea": "Underkropp",
+        "Exercises": [
+          {
+            "Name": "Utfall",
+            "SetsAndReps": "3 set x 10 reps"
           },
           {
-            "Name": "Bicycle Crunches",
+            "Name": "H\u00F6ftlyft",
+            "SetsAndReps": "3 set x 12 reps"
+          },
+          {
+            "Name": "Vadpress",
             "SetsAndReps": "3 set x 15 reps"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Id": 5,
+    "ClientId": 2,
+    "Name": "Viktnedg\u00E5ng 4-dagars",
+    "DailyWorkouts": [
+      {
+        "Day": "Dag 1 (M\u00E5ndag)",
+        "FocusArea": "Hela kroppen",
+        "Exercises": [
+          {
+            "Name": "Kettlebell Sving",
+            "SetsAndReps": "3 set x 12 reps"
           },
           {
-            "Name": "30 min l\u00F6pning",
-            "SetsAndReps": "N/A"
+            "Name": "Hantelkn\u00E4b\u00F6j",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Planka",
+            "SetsAndReps": "3 set x 30 sek"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 2 (Tisdag)",
+        "FocusArea": "\u00D6verkropp",
+        "Exercises": [
+          {
+            "Name": "B\u00E4nkpress",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Chins",
+            "SetsAndReps": "3 set x 8 reps"
+          },
+          {
+            "Name": "Hantelpress",
+            "SetsAndReps": "3 set x 10 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 3 (Torsdag)",
+        "FocusArea": "Nedre kroppen",
+        "Exercises": [
+          {
+            "Name": "Marklyft",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Utfall",
+            "SetsAndReps": "3 set x 10 reps"
+          },
+          {
+            "Name": "Vadpress",
+            "SetsAndReps": "3 set x 15 reps"
+          }
+        ]
+      },
+      {
+        "Day": "Dag 4 (Fredag)",
+        "FocusArea": "Kondition",
+        "Exercises": [
+          {
+            "Name": "Intervalltr\u00E4ning",
+            "SetsAndReps": "20 min"
+          },
+          {
+            "Name": "Cykel",
+            "SetsAndReps": "30 min"
+          },
+          {
+            "Name": "Hoppande Jacks",
+            "SetsAndReps": "3 set x 15 reps"
           }
         ]
       }

--- a/FitnessProgressTracker.csproj
+++ b/FitnessProgressTracker.csproj
@@ -15,7 +15,7 @@
 
 	<ItemGroup>
 	  <None Update=".env">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </None>
 	</ItemGroup>
 

--- a/Models/Appointment.cs
+++ b/Models/Appointment.cs
@@ -13,7 +13,7 @@ namespace FitnessProgressTracker.Models
 		public DateTime Date { get; set; }
 		public int ClientId { get; set; }
 		public int PtId { get; set; }
-		public string Notes { get; set; }
+		public string? Notes { get; set; }
 
     }
 }

--- a/Models/Client.cs
+++ b/Models/Client.cs
@@ -11,8 +11,8 @@ namespace FitnessProgressTracker.Models
     public class Client : User
     {
         
-		public WorkoutPlan CurrentWorkoutPlan { get; set; }
-		public DietPlan CurrentDietPlan { get; set; }// Koppling till PT
+		public WorkoutPlan? CurrentWorkoutPlan { get; set; }
+		public DietPlan? CurrentDietPlan { get; set; }// Koppling till PT
         public int AssignedPtId { get; set; }
 
         // Kopplingar till scheman och loggar (bara ID:n)
@@ -24,5 +24,6 @@ namespace FitnessProgressTracker.Models
         public string GoalDescription { get; set; } = "Inget mål satt";
         public double TargetWeight { get; set; } // t.ex. 75.5 kg
         public int WorkoutsPerWeek { get; set; } // t.ex. 3
+        public int TargetCalories { get; set; }
     }
 }

--- a/Models/DailyMealPlan.cs
+++ b/Models/DailyMealPlan.cs
@@ -8,11 +8,11 @@ namespace FitnessProgressTracker.Models
 {
     public class DailyMealPlan
     {
-        public string Day { get; set; } // t.ex. "Måndag - Söndag (alla dagar)"
-        public string Breakfast { get; set; }
-        public string Lunch { get; set; }
-        public string Dinner { get; set; }
-        public string Snacks { get; set; }
+        public string? Day { get; set; }
+        public string? Breakfast { get; set; }
+        public string? Lunch { get; set; }
+        public string? Dinner { get; set; }
+        public string? Snacks { get; set; }
         public int TotalCalories { get; set; }
     }
 }

--- a/Models/DailyWorkout.cs
+++ b/Models/DailyWorkout.cs
@@ -8,8 +8,8 @@ namespace FitnessProgressTracker.Models
 {
     public class DailyWorkout
     {
-        public string Day { get; set; } // t.ex. "Måndag" eller "Dag 1"
-        public string FocusArea { get; set; } // t.ex. "Bröst/Triceps"
+        public string? Day { get; set; } // t.ex. "Måndag" eller "Dag 1"
+        public string? FocusArea { get; set; } // t.ex. "Bröst/Triceps"
         public List<Exercise> Exercises { get; set; } = new List<Exercise>();
     }
 }

--- a/Models/DietPlan.cs
+++ b/Models/DietPlan.cs
@@ -11,7 +11,7 @@ namespace FitnessProgressTracker.Models
     {
         public int Id { get; set; }
         public int ClientId { get; set; }
-        public string Name { get; set; } // t.ex. "Viktnedgång 2000kcal"
+        public string? Name { get; set; } // t.ex. "Viktnedgång 2000kcal"
         public List<DailyMealPlan> DailyMeals { get; set; } = new List<DailyMealPlan>();
     }
 }

--- a/Models/Exercise.cs
+++ b/Models/Exercise.cs
@@ -8,7 +8,7 @@ namespace FitnessProgressTracker.Models
 {
     public class Exercise
     {
-        public string Name { get; set; } // t.ex. "Bänkpress"
-        public string SetsAndReps { get; set; } // t.ex. "3 set x 10 reps"
+        public string? Name { get; set; } // t.ex. "Bänkpress"
+        public string? SetsAndReps { get; set; } // t.ex. "3 set x 10 reps"
     }
 }

--- a/Models/ProgressLog.cs
+++ b/Models/ProgressLog.cs
@@ -12,7 +12,7 @@ namespace FitnessProgressTracker.Models
 		public int Id { get; set; }
 		public DateTime Date { get; set; }
 		public double Weight { get; set; }
-		public string Notes { get; set; }
+		public string? Notes { get; set; }
 
         public int ClientId { get; set; }
 

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -11,11 +11,11 @@ namespace FitnessProgressTracker.Models
 	public abstract class User
 	{
 		public int Id { get; set; }
-		public string Username { get; set; }
-		public string PasswordHash { get; set; }
-		public string FirstName { get; set; }
-		public string LastName { get; set; }
-        public string Role { get; set; }
+		public string? Username { get; set; }
+		public string? PasswordHash { get; set; }
+		public string? FirstName { get; set; }
+		public string? LastName { get; set; }
+        public string? Role { get; set; }
 
 
     }

--- a/Models/WorkoutPlan.cs
+++ b/Models/WorkoutPlan.cs
@@ -11,7 +11,7 @@ namespace FitnessProgressTracker.Models
     {
         public int Id { get; set; }
         public int ClientId { get; set; }
-        public string Name { get; set; } // t.ex. "Viktnedgång 4 dagar"
+        public string? Name { get; set; } // t.ex. "Viktnedgång 4 dagar"
         public List<DailyWorkout> DailyWorkouts { get; set; } = new List<DailyWorkout>();
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -35,23 +35,20 @@ namespace FitnessProgressTracker
 
                 // 4. Skapa Services (Beroende Injection)
 
-                // AiService (behövs av ScheduleService)
                 AiService aiService = new AiService();
-
-                // ClientService (behövs av Menu och PtMenu)
-                ClientService clientService = new ClientService(clientStore);
-
-                // ScheduleService (behövs av PtMenu - denna behöver MASSOR av dependencies)
-                ScheduleService scheduleService = new ScheduleService(clientStore, workoutStore, dietStore, aiService);
-
-                // LoginService (behövs av Menu)
+                             
+                ScheduleService scheduleService = new ScheduleService(clientStore, workoutStore, dietStore, logsStore, aiService);
+                               
+                ClientService clientService = new ClientService(clientStore, scheduleService);
+                                
+                ProgressService progressService = new ProgressService(logsStore, clientService);
+                                
+                clientService.SetProgressService(progressService);
+                               
                 LoginService loginService = new LoginService(clientStore, ptStore);
 
-                // ProgressService (behövs av PtMenu för att visa klientens framsteg)
-                ProgressService progressService = new ProgressService(logsStore, clientService);
-
-
-                // 5. Skapa Huvudmenyn (Nu finns alla variabler!)
+                
+                
                 Menu mainMenu = new Menu(loginService, clientService, scheduleService, progressService);
 
                 // 6. Kör loopen

--- a/Services/JsonDataStore.cs
+++ b/Services/JsonDataStore.cs
@@ -39,7 +39,7 @@ namespace FitnessProgressTracker.Services
                 }
 
                 // 4. Konvertera (Deserialisera) JSON-texten till en List<T> och returnera den
-                return JsonSerializer.Deserialize<List<T>>(json);
+                return JsonSerializer.Deserialize<List<T>>(json) ?? new List<T>();
             }
             catch (Exception ex)
             {
@@ -58,8 +58,8 @@ namespace FitnessProgressTracker.Services
             try
             {
                 // 1. Kontrollera om mappen ("data/") existerar
-                string directory = Path.GetDirectoryName(_filePath);
-                if (!Directory.Exists(directory))
+                string? directory = Path.GetDirectoryName(_filePath);
+                if (directory != null && !Directory.Exists(directory))
                 {
                     // Skapa mappen om den inte finns
                     Directory.CreateDirectory(directory);

--- a/Services/LoginService.cs
+++ b/Services/LoginService.cs
@@ -48,8 +48,7 @@ namespace FitnessProgressTracker.Services
                 // Ladda ALLA användare (både klienter och PTs)
                 List<User> allUsers = LoadAllUsers();
 
-                bool usernameExists = allUsers.Any(u =>
-                    u.Username.Equals(username, StringComparison.InvariantCultureIgnoreCase));
+                bool usernameExists = allUsers.Any(u => string.Equals(u.Username, username, StringComparison.InvariantCultureIgnoreCase));
 
                 if (usernameExists)
                 {
@@ -90,7 +89,8 @@ namespace FitnessProgressTracker.Services
                 // Ladda ALLA användare
                 List<User> allUsers = LoadAllUsers();
 
-                User user = allUsers.FirstOrDefault(u =>
+                User? user = allUsers.FirstOrDefault(u =>
+                    !string.IsNullOrEmpty(u.Username) &&
                     u.Username.Equals(username, StringComparison.InvariantCultureIgnoreCase) &&
                     u.PasswordHash == password);
 

--- a/Services/ProgressService.cs
+++ b/Services/ProgressService.cs
@@ -66,5 +66,11 @@ namespace FitnessProgressTracker.Services
 
             AnsiConsole.Write(table);
         }
+
+        public void DeleteAllProgress()
+        {
+            // Använd _logStore istället för _progressStore
+            _logStore.Save(new List<ProgressLog>());
+        }
     }
 }

--- a/Services/ScheduleService.cs
+++ b/Services/ScheduleService.cs
@@ -1,5 +1,6 @@
 ﻿using FitnessProgressTracker.Models;
 using FitnessProgressTracker.Services.Interfaces;
+using FitnessProgressTracker.UI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,24 +16,20 @@ namespace FitnessProgressTracker.Services
 		// Datalager för klienter
 		private readonly IDataStore<Client> _clientStore;
 
-
 		// Datalager för träningsplaner
 		private readonly IDataStore<WorkoutPlan> _workoutStore;
 
-
 		// Datalager för kostplaner
 		private readonly IDataStore<DietPlan> _dietStore;
-
 
 		// AI-tjänst som genererar planer
 		private readonly AiService _aiService;
         private readonly IDataStore<ProgressLog> _logStore;
 
-
-        // NYTT: temporära fält för review/ACCEPT-flödet
-        // NYTT: Dessa håller senaste AI-genererade planer i minnet tills PT accepterar.
-        private WorkoutPlan _pendingWorkoutPlan; // NYTT: temporär träningsplan
-		private DietPlan _pendingDietPlan;       // NYTT: temporär kostplan
+        private WorkoutPlan? _previousWorkoutProposal;
+        private WorkoutPlan? _pendingWorkoutPlan;
+        private DietPlan? _previousDietProposal;
+        private DietPlan? _pendingDietPlan;
 
 
         // Konstruktor: tar emot alla nödvändiga services och datalager
@@ -51,20 +48,12 @@ namespace FitnessProgressTracker.Services
             _aiService = aiService;
         }
 
-        public ScheduleService(IDataStore<Client> clientStore, IDataStore<WorkoutPlan> workoutStore, IDataStore<DietPlan> dietStore, AiService aiService)
-        {
-            _clientStore = clientStore;
-            _workoutStore = workoutStore;
-            _dietStore = dietStore;
-            _aiService = aiService;
-        }
-
         // Skapar ett träningsschema via AI men sparar EJ till filen.
         // Istället sparas resultatet i _pendingWorkoutPlan för granskning.
-        public async Task<WorkoutPlan> CreateAndLinkWorkoutPlan(int clientId, string goal, int daysPerWeek)
+        public async Task<WorkoutPlan?> CreateAndLinkWorkoutPlan(int clientId, string goal, int daysPerWeek)
 		{
 			// 1) Anropa AI: be om ett förslag
-			WorkoutPlan plan = await _aiService.GenerateWorkoutPlan(goal, daysPerWeek);
+			WorkoutPlan? plan = await _aiService.GenerateWorkoutPlan(goal, daysPerWeek);
 
 			// 2) Kontrollera om AI:n lyckades
 			if (plan == null)
@@ -86,7 +75,7 @@ namespace FitnessProgressTracker.Services
 
 
 		// NYTT: Denna metod sparar det pending-schemat till fil och kopplar till klient.
-		public WorkoutPlan CommitPendingWorkoutPlan(int clientId)
+		public WorkoutPlan? CommitPendingWorkoutPlan(int clientId)
 		{
 			if (_pendingWorkoutPlan == null)
 				return null;
@@ -106,9 +95,9 @@ namespace FitnessProgressTracker.Services
 
 			// 5) Uppdatera klientens lista med nya plan-id
 			List<Client> allClients = _clientStore.Load();
-			Client clientToUpdate = allClients.FirstOrDefault(c => c.Id == clientId);
+            Client? clientToUpdate = allClients.FirstOrDefault(c => c.Id == clientId);
 
-			if (clientToUpdate != null)
+            if (clientToUpdate != null)
 			{
 				if (clientToUpdate.WorkoutPlanIds == null)
 					clientToUpdate.WorkoutPlanIds = new List<int>();
@@ -126,10 +115,10 @@ namespace FitnessProgressTracker.Services
 	
 
 		// Genererar kostplan via AI men sparar EJ i fil.
-		public async Task<DietPlan> CreateAndLinkDietPlan(int clientId, string goalDescription, int targetCalories)
+		public async Task<DietPlan?> CreateAndLinkDietPlan(int clientId, string goalDescription, int targetCalories)
 		{
 			// 1) Anropa AI:n för att generera en dietplan
-			DietPlan plan = await _aiService.GenerateDietPlan(goalDescription, targetCalories);
+			DietPlan? plan = await _aiService.GenerateDietPlan(goalDescription, targetCalories);
 
 			// 2) Kontrollera om AI:n lyckades
 			if (plan == null)
@@ -150,13 +139,18 @@ namespace FitnessProgressTracker.Services
 	
 		
 		// NYTT: Sparar pending dietplan till fil och länkar till klient
-		public DietPlan CommitPendingDietPlan(int clientId)
+		public DietPlan? CommitPendingDietPlan(int clientId)
 		{
 			if (_pendingDietPlan == null)
 				return null;
 
-			// 1) Ladda alla kostplaner
-			List<DietPlan> allPlans = _dietStore.Load();
+            // VIKTIGT: Spara det gamla pending-värdet till previous
+            // INNAN vi skriver över det med det nya schemat.
+            _previousDietProposal = null; // Rensa förra versionen vid en lyckad commit
+
+
+            // 1) Ladda alla kostplaner
+            List<DietPlan> allPlans = _dietStore.Load();
 
 			// 2) Sätt nytt ID
 			_pendingDietPlan.Id = allPlans.Count > 0 ? allPlans.Max(p => p.Id) + 1 : 1;
@@ -170,7 +164,7 @@ namespace FitnessProgressTracker.Services
 
 			// 5) Uppdatera klientens DietPlanIds
 			List<Client> allClients = _clientStore.Load();
-			Client clientToUpdate = allClients.FirstOrDefault(c => c.Id == clientId);
+			Client? clientToUpdate = allClients.FirstOrDefault(c => c.Id == clientId);
 
 			if (clientToUpdate != null)
 			{
@@ -189,9 +183,11 @@ namespace FitnessProgressTracker.Services
 
         public void CleanUpClientData(List<int> clientIdsToDelete)
         {
+            // Denna metod rensar alla länkar i databasen när en klient tas bort.
+
             // === 1. Rensa träningsscheman ===
             List<WorkoutPlan> workouts = _workoutStore.Load();
-            // Tar bort alla scheman där schemats ClientId finns i clientIdsToDelete-listan
+            // Tar bort alla scheman där schemats ClientId finns i listan
             workouts.RemoveAll(wp => clientIdsToDelete.Contains(wp.ClientId));
             _workoutStore.Save(workouts);
 
@@ -206,6 +202,88 @@ namespace FitnessProgressTracker.Services
             _logStore.Save(logs);
         }
 
+        public WorkoutPlan? RevertToPreviousWorkoutProposal()
+        {
+            // 1. Kontrollera om det finns något att återgå till.
+            if (_previousWorkoutProposal == null)
+            {
+                // Returnera den aktuella pending-planen (oförändrad)
+                return _pendingWorkoutPlan;
+            }
+
+            // 2. SWAP-LOGIK (Simulerar Ångra/Redo mellan två förslag)
+            var temp = _pendingWorkoutPlan; // Steg 1: Spara den aktuella planen temporärt
+
+            _pendingWorkoutPlan = _previousWorkoutProposal; // Steg 2: Återställ till den tidigare planen
+
+            _previousWorkoutProposal = temp; // Steg 3: Spara den gamla "nuvarande" som den nya "previous"
+
+            return _pendingWorkoutPlan;
+        }
+
+        public DietPlan? RevertToPreviousDietProposal()
+        {
+            // Om det inte finns något att återgå till, returnera den aktuella
+            if (_previousDietProposal == null)
+            {
+                return _pendingDietPlan;
+            }
+
+            // SWAP-LOGIK (Simulerar Ångra/Redo mellan två förslag)
+            // 1. Spara den aktuella planen temporärt
+            var temp = _pendingDietPlan;
+
+            // 2. Återställ till den tidigare planen
+            _pendingDietPlan = _previousDietProposal;
+
+            // 3. Spara den aktuella (som just blev bortvald) som den nya "previous"
+            _previousDietProposal = temp;
+
+            return _pendingDietPlan;
+        }
+
+        public WorkoutPlan? GetPreviousWorkoutProposal()
+        {
+            return _previousWorkoutProposal;
+        }
+
+        public DietPlan? GetPreviousDietProposal()
+        {
+            return _previousDietProposal;
+        }
+
+        public void SavePendingAsPreviousDietProposal()
+        {
+            if (_pendingDietPlan != null)
+            {
+                // Denna metod flyttar den aktuella pending-planen till previous-slot
+                // för att möjliggöra "Ångra" i UI.
+
+                // Kontrollera om det finns ett schema i pending att flytta
+
+                _previousDietProposal = _pendingDietPlan;
+            }
+        }
+
+        public void SavePendingAsPreviousWorkoutProposal()
+        {
+            // Denna metod flyttar den aktuella pending-planen till previous-slot
+            // för att möjliggöra "Ångra" i UI.
+
+            // Kontrollera om det finns ett schema i pending att flytta
+            if (_pendingWorkoutPlan != null)
+            {
+                _previousWorkoutProposal = _pendingWorkoutPlan;
+            }
+
+        }
+
+        public void DeleteAllPlans()
+        {
+            // Spara tomma listor för att skriva över befintlig data
+            _workoutStore.Save(new List<WorkoutPlan>());
+            _dietStore.Save(new List<DietPlan>());
+        }
 
     }
 

--- a/UI/Menu.cs
+++ b/UI/Menu.cs
@@ -113,13 +113,13 @@ namespace FitnessProgressTracker.UI
                             {
                                 // Skapa och visa Klient-menyn
                                 ClientMenu clientMenu = new ClientMenu();
-                                clientMenu.Show(loggedInUser as Client); // "as Client" konverterar
+                                clientMenu.Show((Client)loggedInUser); 
                             }
                             else if (loggedInUser.Role == "PT")
                             {
                                 // Skapa och visa PT-menyn
                                 PtMenu ptMenu = new PtMenu(_clientService, _scheduleService, _progressService);
-                                ptMenu.Show(loggedInUser as PT); // "as PT" konverterar
+                                ptMenu.Show((PT)loggedInUser);
                             }
                             else
                             {

--- a/UI/PtMenu.cs
+++ b/UI/PtMenu.cs
@@ -2,8 +2,6 @@
 using FitnessProgressTracker.Services;
 using Spectre.Console;
 
-
-
 namespace FitnessProgressTracker.UI
 {
     public class PtMenu
@@ -34,7 +32,6 @@ namespace FitnessProgressTracker.UI
                     AnsiConsole.Clear();
 
                     SpectreUIHelper.AnimatedBanner("COACH MODE", Color.Blue);
-
                     AnsiConsole.MarkupLine("[italic green]Train hard, coach smart![/]");
                     AnsiConsole.MarkupLine("[dim yellow]Välj vad du vill göra idag, coach.[/]");
 
@@ -44,9 +41,11 @@ namespace FitnessProgressTracker.UI
                             .AddChoices(
                                 "👤 Visa min klientlista",
                                 "📊 Se framsteg och statistik",
+                                "🗑️ Ta bort klient(er)",
                                 "🚪 Logga ut")
                     );
 
+                    // Rensa skärmen direkt efter val för renare look
                     AnsiConsole.Clear();
 
                     switch (choice)
@@ -56,313 +55,35 @@ namespace FitnessProgressTracker.UI
                             break;
 
                         case "📊 Se framsteg och statistik":
-                            SpectreUIHelper.Loading("Hämtar klientdata...");
+                            ShowAllClientsProgressOverview(pt);
+                            break;
 
-                            var clients = _clientService.GetClientsForPT(pt.Id) ?? new List<Client>();
-
-                            foreach (var client in clients)
-                            {
-                                if (client == null) continue;
-
-                                var logs = _progressService.GetLogsForClient(client.Id) ?? new List<ProgressLog>();
-
-                                if (logs.Count == 0)
-                                {
-                                    AnsiConsole.MarkupLine($"[yellow]{client.FirstName} {client.LastName} har inga framsteg loggade ännu.[/]");
-                                    continue;
-                                }
-
-                                var table = new Table().AddColumns("Datum", "Vikt (kg)", "Noteringar");
-
-                                foreach (var log in logs)
-                                {
-                                    table.AddRow(
-                                        log.Date.ToShortDateString(),
-                                        log.Weight.ToString("0.0"),
-                                        log.Notes ?? ""
-                                    );
-                                }
-
-                                AnsiConsole.MarkupLine($"[bold underline]{client.FirstName} {client.LastName}[/]");
-                                AnsiConsole.Write(table);
-                                AnsiConsole.WriteLine();
-                            }
-
-                            SpectreUIHelper.Motivation();
+                        case "🗑️ Ta bort klient(er)":
+                            ShowDeleteClientPrompt(pt);
                             break;
 
                         case "🚪 Logga ut":
                             SpectreUIHelper.Success("Du är nu utloggad. Grymt jobbat coach! 💪");
+                            // Vi pausar här så man hinner se hejdå-meddelandet innan programmet stängs
+                            AnsiConsole.MarkupLine("\n[grey]Tryck på valfri tangent för att avsluta...[/]");
+                            Console.ReadKey(true);
                             isRunning = false;
-                            continue;
+                            break;
                     }
 
-                    AnsiConsole.MarkupLine("\n[grey]Tryck på valfri tangent för att återgå till menyn...[/]");
-                    Console.ReadKey(true);
                 }
             }
             catch (Exception ex)
             {
                 SpectreUIHelper.Error($"Ett fel uppstod i PT-menyn: {ex.Message}");
+                Console.ReadKey(true);
             }
         }
 
         // ---------------------------
-        // Hantera en specifik klient
+        // Metoder för klienthantering
         // ---------------------------
-        private void ShowClientActionMenu(Client client)
-        {
-            bool inSubMenu = true;
 
-            while (inSubMenu)
-            {
-                AnsiConsole.Clear();
-                SpectreUIHelper.AnimatedBanner($"HANTERA: {client.FirstName?.ToUpper() ?? "N/A"}", Color.Green);
-
-                var choice = AnsiConsole.Prompt(
-                    new SelectionPrompt<string>()
-                        .Title($"Vad vill du göra med [green]{client.FirstName}[/]?")
-                        .AddChoices(
-                            "🎯 Sätt upp mål",
-                            "🤖 Skapa träningsschema (AI-hjälp)",
-                            "🥗 Skapa kostschema (AI-hjälp)",
-                            "📊 Se framsteg och statistik",
-                            "↩️ Gå tillbaka"
-                        )
-                );
-
-                switch (choice)
-                {
-                    case "🎯 Sätt upp mål":
-                        var goalDesc = AnsiConsole.Ask<string>("Beskriv klientens mål:");
-                        var targetWeight = AnsiConsole.Ask<double>($"Ange målvikt för {client.FirstName} (kg):");
-                        var workoutsPerWeek = AnsiConsole.Ask<int>("Antal pass/vecka:");
-
-                        _clientService.UpdateClientGoals(client.Id, goalDesc, targetWeight, workoutsPerWeek);
-                        client = _clientService.GetClientById(client.Id);
-
-                        SpectreUIHelper.Success($"Mål uppdaterade för {client.FirstName}!");
-                        Console.ReadKey(true);
-                        break;
-
-					case "🤖 Skapa träningsschema (AI-hjälp)":
-						// — Review-flöde för träningsschema —
-						try
-						{
-							// 1) Hämta senaste version av klienten från clientService
-							Client freshClient = _clientService.GetClientById(client.Id);
-
-							// 2) Hämta klientens målbeskrivning (ex: "Bygga styrka")
-							string goal = freshClient.GoalDescription;
-
-							// 3) Fråga PT om antal träningspass per vecka
-							int daysPerWeek = AnsiConsole.Ask<int>("Ange antal träningspass per vecka:");
-
-							// 4) Visa loading/spinner tills AI har skapat schemat
-							WorkoutPlan plan = null; // Här sparas resultatet från AI
-
-							AnsiConsole.Status()
-								.Spinner(Spinner.Known.Dots)
-								.SpinnerStyle(Style.Parse("green"))
-								.Start("AI skapar träningsschema... vänligen vänta...", ctx =>
-								{
-									// Anropa ScheduleService för att skapa ett förslag (sparas som pending)
-									plan = _scheduleService.CreateAndLinkWorkoutPlan(freshClient.Id, goal, daysPerWeek).Result;
-								});
-
-							// 5) Kontrollera att planen verkligen skapades
-							if (plan == null)
-							{
-								SpectreUIHelper.Error("AI kunde inte skapa ett träningsschema. Försök igen senare.");
-								break;
-							}
-
-
-							// 5) UI-loop där PT kan acceptera eller generera nytt
-							bool reviewing = true;
-							while (reviewing)
-							{
-								// Visa tabellen
-								ShowWorkoutPlanReviewTable(plan);
-
-								// Välj handling
-								var action = AnsiConsole.Prompt(
-									new SelectionPrompt<string>()
-										.Title("Välj åtgärd:")
-										.AddChoices("✔ Acceptera och spara", "🔄 Generera nytt", "↩️ Avbryt"));
-
-								switch (action)
-								{
-									case "✔ Acceptera och spara":
-										var saved = _scheduleService.CommitPendingWorkoutPlan(freshClient.Id);
-										if (saved != null)
-											SpectreUIHelper.Success($"Träningsschema '{saved.Name}' sparat!");
-										else
-											SpectreUIHelper.Error("Kunde inte spara träningsschemat.");
-
-										reviewing = false;
-										break;
-
-									case "🔄 Generera nytt":
-										{
-											WorkoutPlan newPlan = null;
-
-											// Spinner medan AI jobbar
-											AnsiConsole.Status()
-												.Spinner(Spinner.Known.Dots)
-												.SpinnerStyle(Style.Parse("green"))
-												.Start("AI skapar ett nytt träningsschema... vänligen vänta...", ctx =>
-												{
-													newPlan = _scheduleService
-														.CreateAndLinkWorkoutPlan(freshClient.Id, goal, daysPerWeek)
-														.Result;
-												});
-
-											if (newPlan == null)
-											{
-												SpectreUIHelper.Error("AI kunde inte generera ett nytt schema.");
-												reviewing = false;
-												break;
-											}
-
-											// Uppdatera aktiv plan
-											plan = newPlan;
-											break;
-										}
-
-									case "↩️ Avbryt":
-										SpectreUIHelper.Error("Inget träningsschema sparades.");
-										reviewing = false;
-										break;
-
-
-
-
-
-
-								}
-							} 
-
-						}
-						catch (Exception ex)
-						{
-							SpectreUIHelper.Error($"Fel: {ex.Message}");
-						}
-
-						// 8) Vänta innan återgång till klientmenyn
-						AnsiConsole.MarkupLine("\n[grey]Tryck tangent för att fortsätta...[/]");
-						Console.ReadKey(true);
-						break;
-
-
-
-					case "🥗 Skapa kostschema (AI-hjälp)":
-						//  — review-flöde för kostschema //
-						try
-						{
-							// 1) Hämta frisk (uppdaterad) klient från clientService
-							Client freshClient = _clientService.GetClientById(client.Id);
-
-							// 2) Hämta klientens målbeskrivning
-							string goal = freshClient.GoalDescription;
-
-							// 3) Fråga PT om dagligt kalorimål
-							int calories = AnsiConsole.Ask<int>("Ange dagligt kalorimål (kcal):");
-
-
-							// 🔥 AI loading (visas tills planen är klar)
-
-							DietPlan plan = null;
-
-							AnsiConsole.Status()
-								.Spinner(Spinner.Known.Dots)
-								.SpinnerStyle(Style.Parse("green"))
-								.Start("AI skapar kostschema... vänligen vänta...", ctx =>
-								{
-
-									// 4) Be ScheduleService skapa ett förslag (sparas som pending i service)
-									plan = _scheduleService
-										.CreateAndLinkDietPlan(freshClient.Id, goal, calories)
-										.Result;
-								});
-
-
-
-							
-							if (plan == null)
-							{
-								SpectreUIHelper.Error("AI kunde inte skapa ett kostschema. Försök igen senare.");
-								break;
-							}
-
-							// 5) Review-loop: visa plan och låt PT acceptera / generera nytt / avbryta
-							bool reviewing = true;
-							while (reviewing)
-							{
-								// Visa schemat i en tabell
-								ShowDietPlanReviewTable(plan);
-
-								// Erbjud val
-								var action = AnsiConsole.Prompt(
-									new SelectionPrompt<string>()
-										.Title("Välj åtgärd:")
-										.AddChoices("✔ Acceptera och spara", "🔄 Generera nytt", "↩️ Avbryt"));
-
-								switch (action)
-								{
-									case "✔ Acceptera och spara":
-										// NYTT: commit sparar pending-plan till fil och länkar till klient
-										var saved = _scheduleService.CommitPendingDietPlan(freshClient.Id);
-										if (saved != null)
-											SpectreUIHelper.Success($"Kostschema '{saved.Name}' sparat!");
-										else
-											SpectreUIHelper.Error("Kunde inte spara kostschemat.");
-										reviewing = false;
-										break;
-
-									case "🔄 Generera nytt":
-										// NYTT: anropa AI igen för ett nytt förslag (ersätt plan)
-										plan = _scheduleService.CreateAndLinkDietPlan(freshClient.Id, goal, calories).Result;
-										if (plan == null)
-										{
-											SpectreUIHelper.Error("AI kunde inte generera ett nytt schema.");
-											reviewing = false;
-										}
-										// loop fortsätter och visar nya plan
-										break;
-
-									case "↩️ Avbryt":
-										// Kassera pending-plan (töm sker i service inte här), visa meddelande
-										SpectreUIHelper.Error("Inget kostschema sparades.");
-										reviewing = false;
-										break;
-								}
-							} // end review loop
-						}
-						catch (Exception ex)
-						{
-							SpectreUIHelper.Error($"Fel: {ex.Message}");
-						}
-						
-						// Pausa innan återgång till meny
-						AnsiConsole.MarkupLine("\n[grey]Tryck tangent för att fortsätta...[/]");
-						Console.ReadKey(true);
-						break;
-
-					case "📊 Se framsteg och statistik":
-                        ShowClientDashboard(client);
-                        break;
-
-                    case "↩️ Gå tillbaka":
-                        inSubMenu = false;
-                        break;
-                }
-            }
-        }
-
-        
-        // Lista klienter
-        
         private void ShowClientListMenu(PT pt)
         {
             SpectreUIHelper.Loading("Hämtar dina klienter...");
@@ -372,28 +93,91 @@ namespace FitnessProgressTracker.UI
             if (!clients.Any())
             {
                 AnsiConsole.MarkupLine("[yellow]Du har inga klienter kopplade till dig ännu.[/]");
+                AnsiConsole.MarkupLine("\n[grey]Tryck tangent för att gå tillbaka...[/]");
+                Console.ReadKey(true);
                 return;
             }
+
+            // Lägg till alternativ för att gå tillbaka
+            Client goBackChoice = new Client { Id = -1, FirstName = "↩️ Gå tillbaka", LastName = "" };
+            var choices = clients.ToList();
+            choices.Add(goBackChoice);
 
             var selectedClient = AnsiConsole.Prompt(
                 new SelectionPrompt<Client>()
                     .Title("Välj en [cyan]klient[/] att hantera:")
-                    .AddChoices(clients.Where(c => c != null))
-                    .UseConverter(c => $"{c.FirstName} {c.LastName}")
+                    .PageSize(15)
+                    .AddChoices(choices)
+                    .UseConverter(c => c.Id == -1
+                        ? $"[yellow]{c.FirstName}[/]"
+                        : $"👤 [white]{c.FirstName} {c.LastName}[/] [grey](ID: {c.Id})[/]")
             );
+
+            // Om "Gå tillbaka" valdes, returnera direkt utan paus
+            if (selectedClient.Id == -1) return;
 
             ShowClientActionMenu(selectedClient);
         }
 
-        // ---------------------------
-        // Klient-dashboard
-        // ---------------------------
+        private void ShowClientActionMenu(Client client)
+        {
+            bool inSubMenu = true;
+
+            while (inSubMenu)
+            {
+                AnsiConsole.Clear();
+                SpectreUIHelper.AnimatedBanner($"HANTERA: {(client.FirstName ?? "N/A").ToUpper()}", Color.Green);
+
+                // Hämta färsk data
+                Client? freshClient = _clientService.GetClientById(client.Id);
+                if (freshClient == null) return;
+
+                var choice = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title($"Vad vill du göra med [green]{freshClient.FirstName}[/]?")
+                        .AddChoices(
+                            "🎯 Sätt upp mål (Skapa nytt mål, tränings- och kostschema)",
+                            "✏️ Redigera mål (Redigera/ändra mål, tränings- och kostschema)",
+                            "📊 Se framsteg och statistik",
+                            "↩️ Gå tillbaka"
+                        )
+                );
+
+                switch (choice)
+                {
+                    case "🎯 Sätt upp mål (Skapa nytt mål, tränings- och kostschema)":
+                        SetGoalAndScheduleFlow(freshClient).Wait();
+                        break;
+
+                    case "✏️ Redigera mål (Redigera/ändra mål, tränings- och kostschema)":
+                        ShowEditGoalHub(freshClient);
+                        break;
+
+                    case "📊 Se framsteg och statistik":
+                        ShowClientDashboard(freshClient);
+                        break;
+
+                    case "↩️ Gå tillbaka":
+                        inSubMenu = false;
+                        break;
+                }
+
+                // Pausa BARA om vi är kvar i menyn (dvs vi har gjort en action).
+                // Om inSubMenu är false (vi valde Gå tillbaka), skippas detta.
+                if (inSubMenu)
+                {
+                    AnsiConsole.MarkupLine("\n[grey]Tryck tangent för att återgå till menyn...[/]");
+                    Console.ReadKey(true);
+                }
+            }
+        }
+
         private void ShowClientDashboard(Client client)
         {
             AnsiConsole.Clear();
             SpectreUIHelper.AnimatedBanner($"DASHBOARD: {client.FirstName}", Color.Green);
 
-            // PT-mål
+            // 1. Målöversikt
             AnsiConsole.MarkupLine("[bold underline green]🎯 PT:s satta mål[/]");
             var goalTable = new Table();
             goalTable.AddColumn("Målbeskrivning");
@@ -405,11 +189,10 @@ namespace FitnessProgressTracker.UI
                 client.TargetWeight.ToString(),
                 client.WorkoutsPerWeek.ToString()
             );
-
             AnsiConsole.Write(goalTable);
             AnsiConsole.WriteLine();
 
-            // Senaste 5 progress-loggar
+            // 2. Senaste loggar
             AnsiConsole.MarkupLine("[bold underline green]📊 Senaste 5 framsteg[/]");
             var logs = _progressService.GetLogsForClient(client.Id)?.Take(5).ToList() ?? new List<ProgressLog>();
 
@@ -432,115 +215,516 @@ namespace FitnessProgressTracker.UI
                         log.Notes ?? ""
                     );
                 }
-
                 AnsiConsole.Write(logTable);
             }
-
             AnsiConsole.WriteLine();
 
-            // Scheman
+            // 3. Schema-IDn
             AnsiConsole.MarkupLine("[bold underline green]📅 Klientens scheman[/]");
-
             var scheduleTable = new Table();
             scheduleTable.AddColumn("WorkoutPlan ID");
             scheduleTable.AddColumn("DietPlan ID");
 
-            int max = Math.Max(
-                client.WorkoutPlanIds?.Count ?? 0,
-                client.DietPlanIds?.Count ?? 0
-            );
+            int max = Math.Max(client.WorkoutPlanIds?.Count ?? 0, client.DietPlanIds?.Count ?? 0);
 
             for (int i = 0; i < max; i++)
             {
                 string workoutId = (client.WorkoutPlanIds != null && i < client.WorkoutPlanIds.Count)
-                    ? client.WorkoutPlanIds[i].ToString()
-                    : "-";
+                    ? client.WorkoutPlanIds[i].ToString() : "-";
 
                 string dietId = (client.DietPlanIds != null && i < client.DietPlanIds.Count)
-                    ? client.DietPlanIds[i].ToString()
-                    : "-";
+                    ? client.DietPlanIds[i].ToString() : "-";
 
                 scheduleTable.AddRow(workoutId, dietId);
             }
-
             AnsiConsole.Write(scheduleTable);
+
+        }
+
+        // ---------------------------
+        // Wizards och Flöden
+        // ---------------------------
+
+        private async Task SetGoalAndScheduleFlow(Client client)
+        {
+            // 1. Sätt/Redigera mål
+            var updatedClient = EditGoalDetails(client);
+            if (updatedClient == null) return; // Avbrutet
+            client = updatedClient;
+
+            // 2. Skapa och granska träningsschema
+            await RunWorkoutReviewLoop(client);
+
+            // 3. Skapa och granska kostschema
+            AnsiConsole.MarkupLine("\n[bold green]Går vidare till KOSTSCHEMA.[/]");
+            await RunDietReviewLoop(client, client.TargetCalories);
+        }
+
+        private void ShowEditGoalHub(Client client)
+        {
+            bool inHub = true;
+            while (inHub)
+            {
+                Client? freshClient = _clientService.GetClientById(client.Id);
+                if (freshClient == null) return;
+
+                AnsiConsole.Clear();
+                SpectreUIHelper.AnimatedBanner($"REDIGERA: {(freshClient.FirstName ?? "Klient").ToUpper()}", Color.Yellow);
+
+                AnsiConsole.MarkupLine($"\n[bold yellow]Nuvarande mål:[/]");
+                AnsiConsole.MarkupLine($"- Pass/vecka: [cyan]{freshClient.WorkoutsPerWeek}[/], Målvikt: [cyan]{freshClient.TargetWeight} kg[/], Kalorier: [cyan]{freshClient.TargetCalories} kcal / dag[/]");
+                AnsiConsole.WriteLine();
+
+                var choice = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("[bold cyan]Vad vill du ändra på?[/]")
+                        .AddChoices(
+                            "🎯 Ändra Målet (Målvikt, Kalorier, Pass/vecka)",
+                            "🏋️ Ändra Träningsplan (Generera nytt schema)",
+                            "🍎 Ändra Kostplan (Generera nytt schema)",
+                            "↩️ Gå tillbaka till Åtgärdsmenyn"
+                        ));
+
+                switch (choice)
+                {
+                    case "🎯 Ändra Målet (Målvikt, Kalorier, Pass/vecka)":
+                        EditGoalDetails(freshClient);
+                        break;
+
+                    case "🏋️ Ändra Träningsplan (Generera nytt schema)":
+                        RunWorkoutReviewLoop(freshClient).Wait();
+                        break;
+
+                    case "🍎 Ändra Kostplan (Generera nytt schema)":
+                        if (freshClient.TargetCalories == 0)
+                        {
+                            SpectreUIHelper.Error("Du måste sätta Dagligt Kalorimål i 'Ändra Målet' först.");
+                            // Paus här så man hinner läsa felet
+                            Console.ReadKey(true);
+                            break;
+                        }
+                        RunDietReviewLoop(freshClient, freshClient.TargetCalories).Wait();
+                        break;
+
+                    case "↩️ Gå tillbaka till Åtgärdsmenyn":
+                        inHub = false;
+                        break;
+                }
+            }
+        }
+
+        private Client? EditGoalDetails(Client client)
+        {
+            try
+            {
+                SpectreUIHelper.AnimatedBanner($"MÅL: {(client.FirstName ?? "Klient").ToUpper()}", Color.Yellow);
+
+                var goalDesc = AnsiConsole.Prompt(
+                    new TextPrompt<string>("[cyan]Beskriv målet:[/]")
+                        .DefaultValue(client.GoalDescription ?? "")
+                        .AllowEmpty()
+                );
+
+                var targetWeight = AnsiConsole.Prompt(
+                    new TextPrompt<double>("[cyan]Ange ny målvikt (kg):[/]")
+                        .DefaultValue(client.TargetWeight)
+                        .Validate(weight =>
+                        {
+                            if (weight < 30 || weight > 300)
+                                return ValidationResult.Error("[red]Målvikt måste vara mellan 30 och 300 kg.[/]");
+                            return ValidationResult.Success();
+                        })
+                );
+
+                var workoutsPerWeek = AnsiConsole.Prompt(
+                    new TextPrompt<int>("[cyan]Antal pass per vecka:[/]")
+                        .DefaultValue(client.WorkoutsPerWeek)
+                        .Validate(days =>
+                        {
+                            if (days < 0 || days > 7)
+                                return ValidationResult.Error("[red]Antal pass per vecka måste vara mellan 0 och 7.[/]");
+                            return ValidationResult.Success();
+                        })
+                );
+
+                var targetCalories = AnsiConsole.Prompt(
+                    new TextPrompt<int>("[cyan]Dagligt Kalorimål (kcal):[/]")
+                        .DefaultValue(client.TargetCalories > 0 ? client.TargetCalories : 2000)
+                        .Validate(calories =>
+                        {
+                            if (calories < 800 || calories > 5000)
+                                return ValidationResult.Error("[red]Kalorimål måste vara mellan 800 och 5000 kcal.[/]");
+                            return ValidationResult.Success();
+                        })
+                );
+
+                _clientService.UpdateClientGoals(client.Id, goalDesc, targetWeight, workoutsPerWeek, targetCalories);
+                SpectreUIHelper.Success($"Mål har uppdaterats för {client.FirstName}!");
+
+                // Kort paus för att visa "Success"-meddelandet, sen gå vidare
+                Thread.Sleep(1500);
+
+                return _clientService.GetClientById(client.Id);
+            }
+            catch (Exception ex)
+            {
+                SpectreUIHelper.Error($"Kunde inte uppdatera mål: {ex.Message}");
+                Console.ReadKey(true);
+                return null;
+            }
+        }
+
+        // ---------------------------
+        // AI Review Loops
+        // ---------------------------
+
+        private async Task RunWorkoutReviewLoop(Client client)
+        {
+            WorkoutPlan? plan = null;
+            bool reviewing = true;
+
+            while (reviewing)
+            {
+                if (plan == null)
+                {
+                    AnsiConsole.Status()
+                        .Spinner(Spinner.Known.Dots)
+                        .SpinnerStyle(Style.Parse("green"))
+                        .Start("AI skapar träningsschema... vänligen vänta...", ctx =>
+                        {
+                            try
+                            {
+                                int days = client.WorkoutsPerWeek;
+                                string goal = client.GoalDescription ?? "Allmän träning";
+                                plan = _scheduleService.CreateAndLinkWorkoutPlan(client.Id, goal, days).Result;
+                            }
+                            catch (Exception ex)
+                            {
+                                SpectreUIHelper.Error($"AI-fel: {ex.InnerException?.Message ?? ex.Message}");
+                                AnsiConsole.MarkupLine("[bold red]Tryck tangent för att fortsätta...[/]");
+                                Console.ReadKey(true);
+                                plan = null;
+                            }
+                        });
+                }
+
+                if (plan == null)
+                {
+                    SpectreUIHelper.Error("Kunde inte skapa träningsschema. Försök igen.");
+                    return;
+                }
+
+                ShowWorkoutPlanReviewTable(plan);
+
+                var choices = new List<string> { "✔ Acceptera och gå vidare", "🔄 Generera nytt" };
+                if (_scheduleService.GetPreviousWorkoutProposal() != null) choices.Add("↩️ Ångra till föregående");
+                choices.Add("❌ Avbryt");
+
+                var action = AnsiConsole.Prompt(new SelectionPrompt<string>().Title("Välj åtgärd:").AddChoices(choices));
+
+                switch (action)
+                {
+                    case "✔ Acceptera och gå vidare":
+                        var saved = _scheduleService.CommitPendingWorkoutPlan(client.Id);
+                        if (saved != null) SpectreUIHelper.Success($"Träningsschema '{saved.Name}' sparat!");
+                        else SpectreUIHelper.Error("Kunde inte spara schemat.");
+                        reviewing = false;
+                        return;
+
+                    case "🔄 Generera nytt":
+                        _scheduleService.SavePendingAsPreviousWorkoutProposal();
+                        plan = null;
+                        AnsiConsole.MarkupLine("[yellow]Genererar nytt träningsschema...[/]");
+                        break;
+
+                    case "↩️ Ångra till föregående":
+                        plan = _scheduleService.RevertToPreviousWorkoutProposal();
+                        break;
+
+                    case "❌ Avbryt":
+                        reviewing = false;
+                        return;
+                }
+            }
+        }
+
+        private async Task RunDietReviewLoop(Client client, int targetCalories)
+        {
+            DietPlan? plan = null;
+            bool reviewing = true;
+
+            while (reviewing)
+            {
+                if (plan == null)
+                {
+                    AnsiConsole.Status()
+                        .Spinner(Spinner.Known.Dots)
+                        .SpinnerStyle(Style.Parse("green"))
+                        .Start("AI skapar kostschema... vänligen vänta...", ctx =>
+                        {
+                            try
+                            {
+                                string goal = client.GoalDescription ?? "Balanserad kost";
+                                plan = _scheduleService.CreateAndLinkDietPlan(client.Id, goal, targetCalories).Result;
+                            }
+                            catch (Exception ex)
+                            {
+                                SpectreUIHelper.Error($"AI-fel: {ex.InnerException?.Message ?? ex.Message}");
+                                plan = null;
+                            }
+                        });
+                }
+
+                if (plan == null)
+                {
+                    SpectreUIHelper.Error("AI kunde inte skapa ett kostschema. Försök igen.");
+                    return;
+                }
+
+                ShowDietPlanReviewTable(plan);
+
+                var choices = new List<string> { "✔ Acceptera och spara", "🔄 Generera nytt" };
+                if (_scheduleService.GetPreviousDietProposal() != null) choices.Add("↩️ Ångra till föregående");
+                choices.Add("❌ Avbryt");
+
+                var action = AnsiConsole.Prompt(new SelectionPrompt<string>().Title("Välj åtgärd:").AddChoices(choices));
+
+                switch (action)
+                {
+                    case "✔ Acceptera och spara":
+                        var saved = _scheduleService.CommitPendingDietPlan(client.Id);
+                        if (saved != null) SpectreUIHelper.Success($"Kostschema '{saved.Name}' sparat!");
+                        else SpectreUIHelper.Error("Kunde inte spara schemat.");
+                        reviewing = false;
+                        break;
+
+                    case "🔄 Generera nytt":
+                        _scheduleService.SavePendingAsPreviousDietProposal();
+                        plan = null;
+                        AnsiConsole.MarkupLine("[yellow]Genererar nytt förslag...[/]");
+                        break;
+
+                    case "↩️ Ångra till föregående":
+                        plan = _scheduleService.RevertToPreviousDietProposal();
+                        break;
+
+                    case "❌ Avbryt":
+                        reviewing = false;
+                        return;
+                }
+            }
+        }
+
+        // ---------------------------
+        // Visualisering (Tabeller)
+        // ---------------------------
+
+        private void ShowDietPlanReviewTable(DietPlan plan)
+        {
+            AnsiConsole.Clear();
+            var weekDays = new[] { "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag", "Söndag" };
+
+            var table = new Table()
+                .Border(TableBorder.Heavy)
+                .Title($"[bold green]{plan.Name}[/]");
+
+            table.AddColumn(new TableColumn("[bold yellow]DAG[/]").Centered().Width(12));
+            table.AddColumn(new TableColumn("[bold green]MÅLTIDER[/]").LeftAligned().Width(15));
+            table.AddColumn(new TableColumn("[bold white]KOSTPLAN[/]").LeftAligned().Width(50));
+
+            for (int i = 0; i < weekDays.Length; i++)
+            {
+                var dayName = weekDays[i];
+                var mealDay = plan.DailyMeals.FirstOrDefault(d => d.Day != null && d.Day.Contains(dayName));
+                var mealSlots = "Frukost\nLunch\nMiddag\nSnacks\n[bold white]Totalt:[/]";
+
+                if (mealDay == null)
+                {
+                    string mealDetails = "[grey]Ingen kostplan satt för denna dag.[/]" + new string('\n', 4);
+                    table.AddRow($"[yellow]{dayName}[/]", $"[green]{mealSlots}[/]", mealDetails);
+                }
+                else
+                {
+                    var mealDetails = $"[white]{mealDay.Breakfast}[/]\n" +
+                                      $"[white]{mealDay.Lunch}[/]\n" +
+                                      $"[white]{mealDay.Dinner}[/]\n" +
+                                      $"[white]{mealDay.Snacks}[/]\n" +
+                                      $"[bold yellow]{mealDay.TotalCalories} kcal[/]";
+
+                    table.AddRow($"[yellow]{dayName}[/]", $"[green]{mealSlots}[/]", mealDetails);
+                }
+
+                if (i < weekDays.Length - 1) table.AddEmptyRow();
+            }
+            AnsiConsole.Write(table);
+        }
+
+        private void ShowWorkoutPlanReviewTable(WorkoutPlan plan)
+        {
+            AnsiConsole.Clear();
+            var weekDays = new[] { "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag", "Söndag" };
+
+            var table = new Table()
+                .Border(TableBorder.Heavy)
+                .Title($"[bold yellow]{plan.Name}[/]")
+                .AddColumn(new TableColumn("[bold yellow]DAG[/]").Centered().Width(12))
+                .AddColumn(new TableColumn("[bold blue]Fokusområde[/]").Centered().Width(15))
+                .AddColumn(new TableColumn("[bold cyan]Övningar[/]").Centered().Width(50));
+
+            for (int i = 0; i < weekDays.Length; i++)
+            {
+                var dayName = weekDays[i];
+                var workoutDay = plan.DailyWorkouts.FirstOrDefault(d => d.Day != null && d.Day.Contains(dayName));
+
+                string focusAreaText;
+                string textContent;
+
+                if (workoutDay == null)
+                {
+                    focusAreaText = "[magenta]Vilodag[/]";
+                    textContent = "[magenta]Återhämtning: Aktivitet kan vara promenad/yoga.[/]" + new string('\n', 5);
+                }
+                else
+                {
+                    var exercisesToDisplay = workoutDay.Exercises.ToList();
+                    string exerciseTextRaw = string.Join("\n",
+                        exercisesToDisplay.Select(ex =>
+                            $"[cyan]{(ex.Name ?? "Okänd övning").Replace('\n', ' ').Trim()}[/] — [grey]{(ex.SetsAndReps ?? "-").Replace('\n', ' ').Trim()}[/]"
+                        ));
+
+                    int lineCount = exercisesToDisplay.Count;
+                    string padding = new string('\n', Math.Max(0, 6 - lineCount));
+
+                    textContent = exerciseTextRaw + padding;
+                    focusAreaText = $"[blue]{workoutDay.FocusArea}[/]";
+                }
+
+                table.AddRow($"[yellow]{dayName}[/]", focusAreaText, textContent);
+            }
+            AnsiConsole.Write(table);
+        }
+
+        // ---------------------------
+        // Administration
+        // ---------------------------
+
+        private void ShowDeleteClientPrompt(PT pt)
+        {
+            try
+            {
+                SpectreUIHelper.Loading("Laddar klientdata...");
+                var clients = _clientService.GetClientsForPT(pt.Id);
+
+                var cancelChoice = new Client { Id = -1, FirstName = "↩️ Avbryt / Gå tillbaka", LastName = "" };
+                var nukeChoice = new Client { Id = -999, FirstName = "🚨 RADERA ALL DATA (Klienter, Scheman, Mål)", LastName = "" };
+
+                var allChoices = new List<Client>();
+                allChoices.AddRange(clients);
+                allChoices.Add(nukeChoice);
+                allChoices.Add(cancelChoice);
+
+                var selectedClients = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<Client>()
+                        .Title("[bold red]HANTERA BORTTAGNING[/]")
+                        .InstructionsText("[grey](Tryck [blue]<space>[/] för att välja, [green]<enter>[/] för att bekräfta)[/]")
+                        .PageSize(12)
+                        .AddChoices(allChoices)
+                        .UseConverter(c =>
+                        {
+                            if (c.Id == -1) return $"[yellow]{c.FirstName}[/]";
+                            if (c.Id == -999) return $"[bold red blink]{c.FirstName}[/]";
+                            return $"❌ {c.FirstName} {c.LastName} (ID: {c.Id})";
+                        })
+                );
+
+                // Hantera "Avbryt" - Returnera direkt utan paus
+                if (selectedClients.Any(c => c.Id == -1))
+                {
+                    AnsiConsole.MarkupLine("[yellow]Åtgärd avbruten.[/]");
+                    return;
+                }
+
+                // Hantera "RADERA ALLT"
+                if (selectedClients.Any(c => c.Id == -999))
+                {
+                    AnsiConsole.MarkupLine("[bold white on red]VARNING: DU HÅLLER PÅ ATT RADERA ALLA KLIENTER OCH ALL DATA![/]");
+                    if (AnsiConsole.Confirm("Är du helt säker? Detta går INTE att ångra.", false))
+                    {
+                        AnsiConsole.Write(new FigletText("ÄR DU SÄKER?").Color(Color.Red));
+                        if (AnsiConsole.Confirm("Bekräfta en sista gång för att radera databasen:"))
+                        {
+                            SpectreUIHelper.Loading("Raderar systemdata...");
+                            _clientService.DeleteAllData();
+                            SpectreUIHelper.Success("Systemet är rensat. Alla klienter och scheman är borta.");
+                            // Paus vid lyckad radering så man hinner se det
+                            Console.ReadKey(true);
+                        }
+                    }
+                    else
+                    {
+                        AnsiConsole.MarkupLine("[green]Puh! Radering avbruten.[/]");
+                    }
+                    return;
+                }
+
+                // Hantera vanliga klienter
+                if (selectedClients.Count > 0)
+                {
+                    if (AnsiConsole.Confirm($"Vill du verkligen ta bort {selectedClients.Count} klient(er)?", false))
+                    {
+                        List<int> clientIdsToDelete = selectedClients.Select(c => c.Id).ToList();
+                        _clientService.DeleteClients(clientIdsToDelete);
+                        SpectreUIHelper.Success($"Borttagning lyckades! {selectedClients.Count} klient(er) raderades.");
+                        // Paus vid lyckad borttagning
+                        Console.ReadKey(true);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                SpectreUIHelper.Error($"Ett fel uppstod: {ex.Message}");
+                Console.ReadKey(true);
+            }
+        }
+
+        private void ShowAllClientsProgressOverview(PT pt)
+        {
+            SpectreUIHelper.Loading("Hämtar klientdata...");
+
+            var clients = _clientService.GetClientsForPT(pt.Id) ?? new List<Client>();
+
+            foreach (var client in clients)
+            {
+                if (client == null) continue;
+
+                var logs = _progressService.GetLogsForClient(client.Id) ?? new List<ProgressLog>();
+
+                if (logs.Count == 0)
+                {
+                    AnsiConsole.MarkupLine($"[yellow]{client.FirstName} {client.LastName} har inga framsteg loggade ännu.[/]");
+                    continue;
+                }
+
+                var table = new Table().AddColumns("Datum", "Vikt (kg)", "Noteringar");
+
+                foreach (var log in logs)
+                {
+                    table.AddRow(
+                        log.Date.ToShortDateString(),
+                        log.Weight.ToString("0.0"),
+                        log.Notes ?? ""
+                    );
+                }
+
+                AnsiConsole.MarkupLine($"[bold underline]{client.FirstName} {client.LastName}[/]");
+                AnsiConsole.Write(table);
+                AnsiConsole.WriteLine();
+            }
+            SpectreUIHelper.Motivation();
+
+            // VIKTIGT: Här måste vi ha en paus, annars rensas tabellen direkt när man kommer till huvudmenyn
             AnsiConsole.MarkupLine("\n[grey]Tryck tangent för att fortsätta...[/]");
             Console.ReadKey(true);
         }
-
-		// NYTT: Metod som visar dietplan i en Spectre.Console-tabell så PT kan granska.
-		private void ShowDietPlanReviewTable(DietPlan plan)
-		{
-			// Rensa skärmen och visa planens namn
-			AnsiConsole.Clear();
-
-			var table = new Table().Title($"[bold green]{plan.Name}[/]");
-
-			// Kolumner: Dag + Måltider
-			table.AddColumn("Dag");
-			table.AddColumn("Måltider");
-
-			// Loop genom varje DailyMealPlan
-			foreach (var daily in plan.DailyMeals)
-			{
-				// Samla alla måltider i en sträng
-				var mealsText = $"Frukost: {daily.Breakfast}\n" +
-								$"Lunch: {daily.Lunch}\n" +
-								$"Middag: {daily.Dinner}\n" +
-								$"Snacks: {daily.Snacks}\n" +
-								$"Totalt: {daily.TotalCalories} kcal";
-
-				// Lägg till en rad i tabellen
-				table.AddRow(daily.Day, mealsText);
-			}
-
-			AnsiConsole.Write(table);
-		}
-
-
-		// Denna metod ritar upp ett veckoschema i en Spectre.Console-tabell
-		// så att PT: kan granska varje dag och övning innan den sparas.
-
-		private void ShowWorkoutPlanReviewTable(WorkoutPlan plan)
-		{
-			
-			AnsiConsole.Clear();
-
-			// Skapar en snygg Spectre.Console-tabell med rundad ram
-			var table = new Table()
-				.Border(TableBorder.Rounded)
-				.Title($"[bold blue]{plan.Name}[/]"); // Visar planens namn högst upp
-
-			// Lägger till kolumner i tabellen
-			table.AddColumn(new TableColumn("[yellow]Dag[/]").Centered());        // Kolumn 1: Dag
-			table.AddColumn(new TableColumn("[green]Fokusområde[/]").Centered()); // Kolumn 2: Fokusområde
-			table.AddColumn(new TableColumn("[cyan]Övningar[/]").LeftAligned());  // Kolumn 3: Listan med övningar
-
-            // Går igenom varje dags träningspass i träningsschemat
-            foreach (var day in plan.DailyWorkouts)
-            {
-                // Bygger en textlista med alla övningar för dagen
-                // Format: "Bänkpress — 4 set × 10 reps"
-                string exerciseText = string.Join("\n",
-                    day.Exercises.Select(ex => $"{ex.Name} — {ex.SetsAndReps}"));
-
-
-
-                // Lägger in en rad i tabellen med dagens info
-                table.AddRow(
-                    $"[bold]{day.Day}[/]",    // Dagens namn (ex: Måndag)
-                    day.FocusArea,            // Fokusområde (ex: Bröst/Triceps)
-                    exerciseText              // Alla övningar för dagen
-                );
-            
-			}
-
-			// Skriver ut tabellen på skärmen
-			AnsiConsole.Write(table);
-		}
-
-
-
-
-	}
+    }
 }


### PR DESCRIPTION
Titel: PT-Meny: Borttagningsfunktioner, UI-uppdatering och Null-fixar

Beskrivning: Här kommer den slutgiltiga uppdateringen för PT-delen. Jag har fokuserat på att få allting stabilt och snyggt inför inlämning.

Vad är nytt?

Hantering av klienter: Nu går det att ta bort klienter via menyn. Jag har även lagt till en funktion för att "Rensa all data" (tömmer JSON-filerna) om vi behöver börja om från noll.

Stabilitet: Jag har gått igenom hela projektet och fixat de gula varningarna vi hade. Har lagt till ? (nullable) och null-checkar så att programmet inte kraschar om data saknas.

Kodstädning: PtMenu.cs är uppstädad. Har tagit bort gammal utkommenterad kod och fixat till kommentarerna så de är tydliga.

UI: Tabellerna för träningsscheman och statistik är uppdaterade för att se bättre ut.

Hur man testar:

Logga in som PT.

Gå till "Ta bort klient(er)" och testa att ta bort en användare (eller avbryt).

Kolla "Se framsteg och statistik" för att se de nya tabellerna.

Navigera runt i menyerna och se att "Gå tillbaka" fungerar smidigt utan onödiga pauser.

Grymt jobbat allihopa! 🚀